### PR TITLE
Add economy and job systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # Samp
+
+## Rozwiazywanie problemu z komunikatem "To rewrite commits in this repository, you must be a collaborator"
+
+Jesli podczas proby wykonania `git push` lub zatwierdzenia zmian w serwisie GitHub pojawia sie powyzszy komunikat, oznacza to, ze uzywane konto lub token dostepowy nie ma prawa zapisu do repozytorium. Poniżej lista kroków, które zazwyczaj rozwiązuja problem:
+
+1. **Zweryfikuj uprawnienia konta**
+   - Zaloguj sie w przegladarce na GitHub i przejdz do repozytorium.
+   - W zakladce **Settings → Collaborators** upewnij sie, ze Twoje konto widnieje na liscie z prawami `Write` lub `Admin`.
+
+2. **Sprawdz adres zdalny (remote)**
+   ```bash
+   git remote -v
+   ```
+   Jezeli adres wskazuje na cudze repozytorium (np. `github.com/inne-konto/projekt.git`), sklonuj wlasny fork albo zmien adres poleceniem:
+   ```bash
+   git remote set-url origin git@github.com:twoje-konto/projekt.git
+   ```
+
+3. **Uzyj poprawnego sposobu uwierzytelnienia**
+   - Dla HTTPS wymagany jest **Personal Access Token** zamiast hasla.
+   - Dla SSH upewnij sie, ze klucz publiczny znajduje sie na Twoim koncie GitHub i agent SSH jest uruchomiony (`ssh-add -l`).
+
+4. **Zaktualizuj lokalne dane autora**
+   ```bash
+   git config user.name "Twoje Imie"
+   git config user.email "twoj.mail@example.com"
+   ```
+   Niepoprawne dane autora nie blokują zapisu, ale ich uzupełnienie eliminuje błędy podczas commitów.
+
+5. **Spróbuj ponownie wypchnac zmiany**
+   ```bash
+   git push origin <twoja-galaz>
+   ```
+   Jezeli mimo wszystko pojawia sie komunikat o braku uprawnien, sprawdz czy nie probujesz nadpisac historii (`--force`) w repozytorium, do ktorego masz tylko dostep do odczytu.
+
+Po wykonaniu powyzszych krokow problem powinien zniknac. W razie dalszych trudnosci warto usunac lokalny katalog i ponownie sklonowac repozytorium korzystajac z wlasnych danych uwierzytelniajacych.

--- a/gamemodes/ProfesjonalnyProjekt.pwn
+++ b/gamemodes/ProfesjonalnyProjekt.pwn
@@ -6,6 +6,7 @@
 #include "../inc/gamemode/core.inc"
 #include "../inc/gamemode/database.inc"
 #include "../inc/gamemode/players.inc"
+#include "../inc/gamemode/properties.inc"
 #include "../inc/gamemode/economy.inc"
 #include "../inc/gamemode/jobs.inc"
 #include "../inc/gamemode/admin.inc"
@@ -18,6 +19,7 @@ public OnGameModeInit()
     Database_CreateStructure();
 
     Players_Init();
+    Properties_Init();
     Economy_Init();
     Jobs_Init();
     Admin_Init();
@@ -37,6 +39,7 @@ public OnGameModeExit()
     Vehicles_Shutdown();
     Jobs_Shutdown();
     Economy_Shutdown();
+    Properties_Shutdown();
     Players_Shutdown();
     Admin_Shutdown();
     Database_Shutdown();
@@ -139,6 +142,10 @@ public OnPlayerEnterCheckpoint(playerid)
 
 public OnPlayerPickUpPickup(playerid, pickupid)
 {
+    if(Properties_OnPlayerPickUpPickup(playerid, pickupid))
+    {
+        return 1;
+    }
     if(Jobs_OnPlayerPickUpPickup(playerid, pickupid))
     {
         return 1;

--- a/gamemodes/ProfesjonalnyProjekt.pwn
+++ b/gamemodes/ProfesjonalnyProjekt.pwn
@@ -1,0 +1,147 @@
+#include <a_samp>
+#include <sqlite>
+#include <Whirlpool>
+#include <sscanf2>
+
+#include "../inc/gamemode/core.inc"
+#include "../inc/gamemode/database.inc"
+#include "../inc/gamemode/players.inc"
+#include "../inc/gamemode/economy.inc"
+#include "../inc/gamemode/jobs.inc"
+#include "../inc/gamemode/admin.inc"
+#include "../inc/gamemode/vehicles.inc"
+
+public OnGameModeInit()
+{
+    Core_Init();
+    Database_Init();
+    Database_CreateStructure();
+
+    Players_Init();
+    Economy_Init();
+    Jobs_Init();
+    Admin_Init();
+    Vehicles_Init();
+
+    SetGameModeText(SERVER_NAME);
+    ShowPlayerMarkers(PLAYER_MARKERS_MODE_GLOBAL);
+    EnableStuntBonusForAll(0);
+    SendRconCommand("hostname " SERVER_NAME);
+    SendRconCommand("language Polski");
+    Core_Log("GameMode wystartowal pomyslnie.");
+    return 1;
+}
+
+public OnGameModeExit()
+{
+    Vehicles_Shutdown();
+    Jobs_Shutdown();
+    Economy_Shutdown();
+    Players_Shutdown();
+    Admin_Shutdown();
+    Database_Shutdown();
+    Core_Shutdown();
+    return 1;
+}
+
+public OnPlayerConnect(playerid)
+{
+    return Players_OnPlayerConnect(playerid);
+}
+
+public OnPlayerDisconnect(playerid, reason)
+{
+    return Players_OnPlayerDisconnect(playerid, reason);
+}
+
+public OnPlayerRequestClass(playerid, classid)
+{
+    return Players_OnPlayerRequestClass(playerid, classid);
+}
+
+public OnPlayerSpawn(playerid)
+{
+    return Players_OnPlayerSpawn(playerid);
+}
+
+public OnPlayerCommandText(playerid, cmdtext[])
+{
+    if(Admin_OnPlayerCommandText(playerid, cmdtext))
+    {
+        return 1;
+    }
+    if(Vehicles_OnPlayerCommandText(playerid, cmdtext))
+    {
+        return 1;
+    }
+    return Players_OnPlayerCommandText(playerid, cmdtext);
+}
+
+public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
+{
+    if(Players_OnDialogResponse(playerid, dialogid, response, listitem, inputtext))
+    {
+        return 1;
+    }
+    if(Vehicles_OnDialogResponse(playerid, dialogid, response, listitem, inputtext))
+    {
+        return 1;
+    }
+    return 0;
+}
+
+public OnPlayerStateChange(playerid, newstate, oldstate)
+{
+    return Players_OnPlayerStateChange(playerid, newstate, oldstate);
+}
+
+public OnVehicleSpawn(vehicleid)
+{
+    return Vehicles_OnVehicleSpawn(vehicleid);
+}
+
+public OnVehicleDeath(vehicleid, killerid)
+{
+    if(Jobs_OnVehicleDeath(vehicleid, killerid))
+    {
+        return 1;
+    }
+    return Vehicles_OnVehicleDeath(vehicleid, killerid);
+}
+
+public OnPlayerEnterVehicle(playerid, vehicleid, ispassenger)
+{
+    return Vehicles_OnPlayerEnterVehicle(playerid, vehicleid, ispassenger);
+}
+
+public OnPlayerExitVehicle(playerid, vehicleid)
+{
+    if(Jobs_OnPlayerExitVehicle(playerid, vehicleid))
+    {
+        return 1;
+    }
+    return Vehicles_OnPlayerExitVehicle(playerid, vehicleid);
+}
+
+public OnRconCommand(cmd[])
+{
+    return Admin_OnRconCommand(cmd);
+}
+
+public OnPlayerEnterCheckpoint(playerid)
+{
+    if(Jobs_OnPlayerEnterCheckpoint(playerid))
+    {
+        return 1;
+    }
+    return 0;
+}
+
+public OnPlayerPickUpPickup(playerid, pickupid)
+{
+    if(Jobs_OnPlayerPickUpPickup(playerid, pickupid))
+    {
+        return 1;
+    }
+    return 0;
+}

--- a/inc/gamemode/admin.inc
+++ b/inc/gamemode/admin.inc
@@ -1,0 +1,222 @@
+#if defined _ADMIN_MODULE_INCLUDED
+    #endinput
+#endif
+#define _ADMIN_MODULE_INCLUDED
+
+#define ADMIN_CHAT_PREFIX "[ADMIN]"
+
+forward Admin_Init();
+forward Admin_Shutdown();
+forward Admin_OnPlayerCommandText(playerid, cmdtext[]);
+forward Admin_OnRconCommand(cmd[]);
+forward Admin_IsPlayerAuthorized(playerid, level);
+forward Admin_LogAction(playerid, const action[]);
+forward Admin_Broadcast(const message[]);
+
+stock Admin_Init()
+{
+    Core_Log("[Admin] Moduly administracyjne gotowe.");
+    return 1;
+}
+
+stock Admin_Shutdown()
+{
+    Core_Log("[Admin] Moduly administracyjne zamkniete.");
+    return 1;
+}
+
+stock Admin_OnPlayerCommandText(playerid, cmdtext[])
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        return 0;
+    }
+
+    new command[32], params[192];
+    sscanf(cmdtext, "s[32]S()[192]", command, params);
+
+    if(!strcmp(command, "/a", true))
+    {
+        if(!Admin_IsPlayerAuthorized(playerid, 2))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Brak uprawnien administracyjnych.");
+            return 1;
+        }
+
+        if(!params[0])
+        {
+            SendClientMessage(playerid, COLOR_WARNING, "Uzycie: /a <wiadomosc>");
+            return 1;
+        }
+
+        new name[MAX_PLAYER_NAME + 1];
+        GetPlayerName(playerid, name, sizeof(name));
+
+        new message[192];
+        format(message, sizeof(message), "%s %s: %s", ADMIN_CHAT_PREFIX, name, params);
+
+        for(new i = 0; i < MAX_PLAYERS; i++)
+        {
+            if(IsPlayerConnected(i) && PlayerData[i][pLogged] && Admin_IsPlayerAuthorized(i, 2))
+            {
+                SendClientMessage(i, COLOR_ADMIN, message);
+            }
+        }
+
+        Admin_LogAction(playerid, "Wyslal wiadomosc na czacie administracyjnym.");
+        return 1;
+    }
+
+    if(!strcmp(command, "/setlevel", true))
+    {
+        if(!Admin_IsPlayerAuthorized(playerid, 3))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Brak uprawnien do zmiany poziomu.");
+            return 1;
+        }
+
+        new targetid, level;
+        if(sscanf(params, "dd", targetid, level))
+        {
+            SendClientMessage(playerid, COLOR_WARNING, "Uzycie: /setlevel <id> <poziom>");
+            return 1;
+        }
+
+        if(!IsPlayerConnected(targetid))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Wybrany gracz nie jest polaczony.");
+            return 1;
+        }
+
+        PlayerData[targetid][pLevel] = level;
+
+        new query[128];
+        format(query, sizeof(query), "UPDATE accounts SET level=%d WHERE id=%d", level, PlayerData[targetid][pID]);
+        Database_Execute(query);
+
+        new name[MAX_PLAYER_NAME + 1];
+        GetPlayerName(targetid, name, sizeof(name));
+
+        new info[160];
+        format(info, sizeof(info), "Ustawiles poziom gracza %s na %d.", name, level);
+        SendClientMessage(playerid, COLOR_SUCCESS, info);
+
+        format(info, sizeof(info), "Administrator ustawil Twoj poziom na %d.", level);
+        SendClientMessage(targetid, COLOR_WARNING, info);
+
+        Admin_LogAction(playerid, "Zmiana poziomu gracza.");
+        return 1;
+    }
+
+    if(!strcmp(command, "/kick", true))
+    {
+        if(!Admin_IsPlayerAuthorized(playerid, 2))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Brak uprawnien do wyrzucania graczy.");
+            return 1;
+        }
+
+        new targetid;
+        if(sscanf(params, "d", targetid))
+        {
+            SendClientMessage(playerid, COLOR_WARNING, "Uzycie: /kick <id>");
+            return 1;
+        }
+
+        if(!IsPlayerConnected(targetid))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Wybrany gracz nie jest polaczony.");
+            return 1;
+        }
+
+        new name[MAX_PLAYER_NAME + 1];
+        GetPlayerName(targetid, name, sizeof(name));
+
+        Kick(targetid);
+
+        new message[144];
+        format(message, sizeof(message), "Gracz %s zostal wyrzucony z serwera.", name);
+        SendClientMessageToAll(COLOR_WARNING, message);
+
+        Admin_LogAction(playerid, "Wyrzucil gracza z serwera.");
+        return 1;
+    }
+
+    if(!strcmp(command, "/announce", true))
+    {
+        if(!Admin_IsPlayerAuthorized(playerid, 2))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Brak uprawnien do ogloszen.");
+            return 1;
+        }
+
+        if(!params[0])
+        {
+            SendClientMessage(playerid, COLOR_WARNING, "Uzycie: /announce <wiadomosc>");
+            return 1;
+        }
+
+        new message[220];
+        format(message, sizeof(message), "[OGL] %s", params);
+        Admin_Broadcast(message);
+
+        Admin_LogAction(playerid, "Wyslal ogloszenie globalne.");
+        return 1;
+    }
+
+    return 0;
+}
+
+stock Admin_OnRconCommand(cmd[])
+{
+    new lowered[64];
+    format(lowered, sizeof(lowered), "%s", cmd);
+    strlower(lowered);
+
+    if(!strcmp(lowered, "reloadadmins", true))
+    {
+        Core_Log("[Admin] Przeladowanie listy administratorow nie jest wymagane w tym trybie.");
+        return 1;
+    }
+    return 0;
+}
+
+stock Admin_IsPlayerAuthorized(playerid, level)
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        return 0;
+    }
+    return PlayerData[playerid][pLevel] >= level;
+}
+
+stock Admin_LogAction(playerid, const action[])
+{
+    new name[MAX_PLAYER_NAME + 1];
+    GetPlayerName(playerid, name, sizeof(name));
+
+    new escapedName[2 * MAX_PLAYER_NAME + 1];
+    Database_Escape(name, escapedName, sizeof(escapedName));
+
+    new escapedAction[256];
+    Database_Escape(action, escapedAction, sizeof(escapedAction));
+
+    new query[256];
+    format(query, sizeof(query), "INSERT INTO admin_logs (admin_name, action) VALUES ('%s', '%s')", escapedName, escapedAction);
+    Database_Execute(query);
+    return 1;
+}
+
+stock Admin_Broadcast(const message[])
+{
+    for(new i = 0; i < MAX_PLAYERS; i++)
+    {
+        if(IsPlayerConnected(i))
+        {
+            GameTextForPlayer(i, message, 4000, 3);
+            SendClientMessage(i, COLOR_INFO, message);
+        }
+    }
+    return 1;
+}
+

--- a/inc/gamemode/core.inc
+++ b/inc/gamemode/core.inc
@@ -1,0 +1,114 @@
+#if defined _CORE_MODULE_INCLUDED
+    #endinput
+#endif
+#define _CORE_MODULE_INCLUDED
+
+#define SERVER_NAME "Profesjonalny Projekt RP"
+#define SERVER_VERSION "1.0.0"
+#define SERVER_DB_FILE "scriptfiles/projekt.db"
+
+#define COLOR_WHITE 0xFFFFFFFF
+#define COLOR_INFO 0x00B9FFFF
+#define COLOR_ERROR 0x9C0000FF
+#define COLOR_SUCCESS 0x1DB954FF
+#define COLOR_WARNING 0xF1C40FFF
+#define COLOR_ADMIN 0xE67E22FF
+
+#define MAX_LOGIN_ATTEMPTS 3
+#define MAX_ACCOUNT_PASSWORD 64
+#define MAX_ACCOUNT_SALT 24
+
+new DB:gDatabaseHandle = DB:0;
+
+enum E_PLAYER_DATA
+{
+    bool:pConnected,
+    bool:pLogged,
+    bool:pRegistered,
+    bool:pSpawnPrepared,
+    pLoginAttempts,
+    pID,
+    pLevel,
+    pMoney,
+    pSkin,
+    Float:pSpawnX,
+    Float:pSpawnY,
+    Float:pSpawnZ,
+    Float:pSpawnAngle,
+    pPassword[MAX_ACCOUNT_PASSWORD + 1],
+    pSalt[MAX_ACCOUNT_SALT + 1],
+    pIP[16],
+    pLastLogin[32],
+    pSessionStart,
+    pPlayTime,
+    pBankBalance,
+    pPaycheck,
+    pJobID,
+    pJobExperience
+};
+
+new PlayerData[MAX_PLAYERS][E_PLAYER_DATA];
+
+forward Core_Init();
+forward Core_Shutdown();
+forward Core_Log(const message[]);
+forward Core_FormatTime(datetime[], length);
+forward Core_ResetPlayerData(playerid);
+
+stock Core_Init()
+{
+    print("[Core] Inicjalizacja podstawowych komponentow...");
+    return 1;
+}
+
+stock Core_Shutdown()
+{
+    print("[Core] Zamkniecie podstawowych komponentow...");
+    return 1;
+}
+
+stock Core_Log(const message[])
+{
+    new timestamp[32];
+    Core_FormatTime(timestamp, sizeof(timestamp));
+    printf("[%s] %s", timestamp, message);
+    return 1;
+}
+
+stock Core_FormatTime(datetime[], length)
+{
+    new year, month, day, hour, minute, second;
+    getdate(year, month, day);
+    gettime(hour, minute, second);
+    format(datetime, length, "%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
+    return 1;
+}
+
+stock Core_ResetPlayerData(playerid)
+{
+    PlayerData[playerid][pConnected] = false;
+    PlayerData[playerid][pLogged] = false;
+    PlayerData[playerid][pRegistered] = false;
+    PlayerData[playerid][pSpawnPrepared] = false;
+    PlayerData[playerid][pLoginAttempts] = 0;
+    PlayerData[playerid][pID] = -1;
+    PlayerData[playerid][pLevel] = 1;
+    PlayerData[playerid][pMoney] = 0;
+    PlayerData[playerid][pSkin] = 0;
+    PlayerData[playerid][pSpawnX] = 1958.3783;
+    PlayerData[playerid][pSpawnY] = 1343.1572;
+    PlayerData[playerid][pSpawnZ] = 15.3746;
+    PlayerData[playerid][pSpawnAngle] = 90.0;
+    PlayerData[playerid][pPassword][0] = '\0';
+    PlayerData[playerid][pSalt][0] = '\0';
+    PlayerData[playerid][pIP][0] = '\0';
+    PlayerData[playerid][pLastLogin][0] = '\0';
+    PlayerData[playerid][pSessionStart] = 0;
+    PlayerData[playerid][pPlayTime] = 0;
+    PlayerData[playerid][pBankBalance] = 0;
+    PlayerData[playerid][pPaycheck] = 0;
+    PlayerData[playerid][pJobID] = 0;
+    PlayerData[playerid][pJobExperience] = 0;
+    return 1;
+}
+

--- a/inc/gamemode/core.inc
+++ b/inc/gamemode/core.inc
@@ -44,7 +44,9 @@ enum E_PLAYER_DATA
     pBankBalance,
     pPaycheck,
     pJobID,
-    pJobExperience
+    pJobExperience,
+    pPropertyID,
+    bool:pPropertySpawn
 };
 
 new PlayerData[MAX_PLAYERS][E_PLAYER_DATA];
@@ -109,6 +111,8 @@ stock Core_ResetPlayerData(playerid)
     PlayerData[playerid][pPaycheck] = 0;
     PlayerData[playerid][pJobID] = 0;
     PlayerData[playerid][pJobExperience] = 0;
+    PlayerData[playerid][pPropertyID] = 0;
+    PlayerData[playerid][pPropertySpawn] = false;
     return 1;
 }
 

--- a/inc/gamemode/database.inc
+++ b/inc/gamemode/database.inc
@@ -1,0 +1,210 @@
+#if defined _DATABASE_MODULE_INCLUDED
+    #endinput
+#endif
+#define _DATABASE_MODULE_INCLUDED
+
+forward Database_Init();
+forward Database_CreateStructure();
+forward Database_Shutdown();
+forward Database_Execute(const query[]);
+forward Database_Escape(const input[], output[], size = sizeof(output));
+forward Database_FetchInt(DBResult:result, const field[]);
+forward Database_FetchString(DBResult:result, const field[], output[], size);
+forward Float:Database_FetchFloat(DBResult:result, const field[]);
+forward Database_LogQuery(const prefix[], const query[]);
+
+stock Database_Init()
+{
+    if(gDatabaseHandle != DB:0)
+    {
+        return 1;
+    }
+
+    gDatabaseHandle = db_open(SERVER_DB_FILE);
+
+    if(gDatabaseHandle == DB:0)
+    {
+        Core_Log("[Database] Blad polaczenia z lokalna baza danych sqlite.");
+        SendRconCommand("exit");
+        return 0;
+    }
+
+    Core_Log("[Database] Nawiazano polaczenie z lokalna baza danych.");
+    return 1;
+}
+
+stock Database_CreateStructure()
+{
+    new query[512];
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS accounts (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "name TEXT UNIQUE," \
+        "password TEXT," \
+        "salt TEXT," \
+        "level INTEGER DEFAULT 1," \
+        "money INTEGER DEFAULT 0," \
+        "skin INTEGER DEFAULT 0," \
+        "spawn_x REAL DEFAULT 1958.3783," \
+        "spawn_y REAL DEFAULT 1343.1572," \
+        "spawn_z REAL DEFAULT 15.3746," \
+        "spawn_angle REAL DEFAULT 90.0," \
+        "ip TEXT," \
+        "last_login TEXT," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS admin_logs (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "admin_name TEXT," \
+        "action TEXT," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS server_logs (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "level TEXT," \
+        "message TEXT," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS vehicles (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "model INTEGER," \
+        "position_x REAL," \
+        "position_y REAL," \
+        "position_z REAL," \
+        "rotation REAL," \
+        "color_1 INTEGER," \
+        "color_2 INTEGER," \
+        "owner TEXT DEFAULT ''," \
+        "respawn_delay INTEGER DEFAULT 300," \
+        "last_driver TEXT DEFAULT '');"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS account_finances (" \
+        "account_id INTEGER PRIMARY KEY," \
+        "bank_balance INTEGER DEFAULT 0," \
+        "paycheck INTEGER DEFAULT 0," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP," \
+        "updated_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS account_jobs (" \
+        "account_id INTEGER PRIMARY KEY," \
+        "job_id INTEGER DEFAULT 0," \
+        "job_experience INTEGER DEFAULT 0," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP," \
+        "updated_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS transactions (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "account_id INTEGER," \
+        "type TEXT," \
+        "amount INTEGER," \
+        "balance_after INTEGER," \
+        "description TEXT," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS job_logs (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "account_id INTEGER," \
+        "job_id INTEGER," \
+        "action TEXT," \
+        "payout INTEGER," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+    return 1;
+}
+
+stock Database_Shutdown()
+{
+    if(gDatabaseHandle != DB:0)
+    {
+        db_close(gDatabaseHandle);
+        gDatabaseHandle = DB:0;
+        Core_Log("[Database] Zamknieto polaczenie z baza danych.");
+    }
+    return 1;
+}
+
+stock Database_Execute(const query[])
+{
+    if(gDatabaseHandle == DB:0)
+    {
+        Core_Log("[Database] Brak polaczenia z baza danych podczas wykonywania zapytania.");
+        return 0;
+    }
+    Database_LogQuery("EXEC", query);
+    new DBResult:result = db_query(gDatabaseHandle, query);
+    if(result)
+    {
+        db_free_result(result);
+    }
+    return 1;
+}
+
+stock Database_Escape(const input[], output[], size = sizeof(output))
+{
+    if(gDatabaseHandle == DB:0)
+    {
+        format(output, size, "%s", input);
+        return 0;
+    }
+    db_escape_string(gDatabaseHandle, input, output, size);
+    return 1;
+}
+
+stock Database_FetchInt(DBResult:result, const field[])
+{
+    if(!result) return 0;
+    new value = db_get_field_assoc_int(result, field);
+    return value;
+}
+
+stock Database_FetchString(DBResult:result, const field[], output[], size)
+{
+    if(!result)
+    {
+        output[0] = '\0';
+        return 0;
+    }
+    db_get_field_assoc(result, field, output, size);
+    return 1;
+}
+
+stock Float:Database_FetchFloat(DBResult:result, const field[])
+{
+    if(!result)
+    {
+        return 0.0;
+    }
+    return db_get_field_assoc_float(result, field);
+}
+
+stock Database_LogQuery(const prefix[], const query[])
+{
+    new message[256];
+    format(message, sizeof(message), "[Database] %s => %s", prefix, query);
+    Core_Log(message);
+    return 1;
+}
+

--- a/inc/gamemode/database.inc
+++ b/inc/gamemode/database.inc
@@ -12,6 +12,8 @@ forward Database_FetchInt(DBResult:result, const field[]);
 forward Database_FetchString(DBResult:result, const field[], output[], size);
 forward Float:Database_FetchFloat(DBResult:result, const field[]);
 forward Database_LogQuery(const prefix[], const query[]);
+forward bool:Database_TableHasColumn(const table[], const column[]);
+forward Database_AddColumnIfMissing(const table[], const column[], const definition[]);
 
 stock Database_Init()
 {
@@ -52,9 +54,14 @@ stock Database_CreateStructure()
         "spawn_angle REAL DEFAULT 90.0," \
         "ip TEXT," \
         "last_login TEXT," \
+        "property_id INTEGER DEFAULT 0," \
+        "property_spawn INTEGER DEFAULT 0," \
         "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
     );
     Database_Execute(query);
+
+    Database_AddColumnIfMissing("accounts", "property_id", "INTEGER DEFAULT 0");
+    Database_AddColumnIfMissing("accounts", "property_spawn", "INTEGER DEFAULT 0");
 
     format(query, sizeof(query),
         "CREATE TABLE IF NOT EXISTS admin_logs (" \
@@ -132,6 +139,36 @@ stock Database_CreateStructure()
         "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
     );
     Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS properties (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "name TEXT," \
+        "price INTEGER DEFAULT 0," \
+        "owner_id INTEGER DEFAULT 0," \
+        "locked INTEGER DEFAULT 0," \
+        "interior INTEGER DEFAULT 0," \
+        "enter_x REAL," \
+        "enter_y REAL," \
+        "enter_z REAL," \
+        "exit_x REAL," \
+        "exit_y REAL," \
+        "exit_z REAL," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP," \
+        "updated_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
+
+    format(query, sizeof(query),
+        "CREATE TABLE IF NOT EXISTS property_logs (" \
+        "id INTEGER PRIMARY KEY AUTOINCREMENT," \
+        "property_id INTEGER," \
+        "account_id INTEGER," \
+        "action TEXT," \
+        "details TEXT," \
+        "created_at TEXT DEFAULT CURRENT_TIMESTAMP);"
+    );
+    Database_Execute(query);
     return 1;
 }
 
@@ -198,6 +235,52 @@ stock Float:Database_FetchFloat(DBResult:result, const field[])
         return 0.0;
     }
     return db_get_field_assoc_float(result, field);
+}
+
+stock bool:Database_TableHasColumn(const table[], const column[])
+{
+    if(gDatabaseHandle == DB:0)
+    {
+        return false;
+    }
+
+    new query[128];
+    format(query, sizeof(query), "PRAGMA table_info(%s);", table);
+
+    new DBResult:result = db_query(gDatabaseHandle, query);
+    if(!result)
+    {
+        return false;
+    }
+
+    new columnName[64];
+    new bool:found = false;
+
+    while(db_next_row(result))
+    {
+        db_get_field_assoc(result, "name", columnName, sizeof(columnName));
+        if(!strcmp(columnName, column, false))
+        {
+            found = true;
+            break;
+        }
+    }
+
+    db_free_result(result);
+    return found;
+}
+
+stock Database_AddColumnIfMissing(const table[], const column[], const definition[])
+{
+    if(Database_TableHasColumn(table, column))
+    {
+        return 0;
+    }
+
+    new query[256];
+    format(query, sizeof(query), "ALTER TABLE %s ADD COLUMN %s %s", table, column, definition);
+    Database_Execute(query);
+    return 1;
 }
 
 stock Database_LogQuery(const prefix[], const query[])

--- a/inc/gamemode/economy.inc
+++ b/inc/gamemode/economy.inc
@@ -1,0 +1,450 @@
+#if defined _ECONOMY_MODULE_INCLUDED
+    #endinput
+#endif
+#define _ECONOMY_MODULE_INCLUDED
+
+#define ECONOMY_PAYDAY_INTERVAL   (600000)
+#define ECONOMY_BASE_SALARY       (250)
+#define ECONOMY_LEVEL_BONUS       (25)
+#define ECONOMY_EXPERIENCE_BONUS  (5)
+#define ECONOMY_MAX_PAYCHECK      (50000)
+#define ECONOMY_MAX_TRANSFER      (100000)
+#define ECONOMY_MIN_TRANSFER      (100)
+
+enum E_ECONOMY_DATA
+{
+    bool:eLoaded
+};
+
+new EconomyData[MAX_PLAYERS][E_ECONOMY_DATA];
+new EconomyPaydayTimer = -1;
+
+forward Economy_Init();
+forward Economy_Shutdown();
+forward Economy_OnAccountLoaded(playerid);
+forward Economy_OnAccountRegistered(playerid);
+forward Economy_OnPlayerLogin(playerid);
+forward Economy_OnPlayerDisconnect(playerid);
+forward Economy_OnPlayerSave(playerid);
+forward Economy_OnPlayerSpawn(playerid);
+forward Economy_OnPlayerCommandText(playerid, cmdtext[]);
+forward Economy_AddPaycheck(playerid, amount, const reason[]);
+
+forward Economy_PaydayTick();
+
+stock Economy_Init()
+{
+    for(new i = 0; i < MAX_PLAYERS; i++)
+    {
+        Economy_ResetPlayer(i);
+    }
+
+    if(EconomyPaydayTimer != -1)
+    {
+        KillTimer(EconomyPaydayTimer);
+    }
+
+    EconomyPaydayTimer = SetTimer("Economy_PaydayTick", ECONOMY_PAYDAY_INTERVAL, true);
+    Core_Log("[Economy] Zainicjalizowano modul finansowy.");
+    return 1;
+}
+
+stock Economy_Shutdown()
+{
+    if(EconomyPaydayTimer != -1)
+    {
+        KillTimer(EconomyPaydayTimer);
+        EconomyPaydayTimer = -1;
+    }
+
+    for(new i = 0; i < MAX_PLAYERS; i++)
+    {
+        if(PlayerData[i][pLogged])
+        {
+            Economy_SavePlayer(i);
+        }
+    }
+
+    Core_Log("[Economy] Zamknieto modul finansowy.");
+    return 1;
+}
+
+stock Economy_ResetPlayer(playerid)
+{
+    EconomyData[playerid][eLoaded] = false;
+    return 1;
+}
+
+stock Economy_OnAccountLoaded(playerid)
+{
+    Economy_ResetPlayer(playerid);
+
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new query[256];
+    format(query, sizeof(query), "SELECT bank_balance, paycheck FROM account_finances WHERE account_id=%d", PlayerData[playerid][pID]);
+
+    new DBResult:result = db_query(gDatabaseHandle, query);
+
+    if(result && db_num_rows(result) > 0)
+    {
+        db_next_row(result);
+        PlayerData[playerid][pBankBalance] = Database_FetchInt(result, "bank_balance");
+        PlayerData[playerid][pPaycheck] = Database_FetchInt(result, "paycheck");
+        EconomyData[playerid][eLoaded] = true;
+    }
+    else
+    {
+        if(result)
+        {
+            db_free_result(result);
+        }
+
+        format(query, sizeof(query), "INSERT INTO account_finances (account_id, bank_balance, paycheck) VALUES (%d, 0, 0)", PlayerData[playerid][pID]);
+        Database_Execute(query);
+
+        PlayerData[playerid][pBankBalance] = 0;
+        PlayerData[playerid][pPaycheck] = 0;
+        EconomyData[playerid][eLoaded] = true;
+        return 1;
+    }
+
+    if(result)
+    {
+        db_free_result(result);
+    }
+
+    return 1;
+}
+
+stock Economy_OnAccountRegistered(playerid)
+{
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new query[256];
+    format(query, sizeof(query), "INSERT INTO account_finances (account_id, bank_balance, paycheck) VALUES (%d, 0, 0)", PlayerData[playerid][pID]);
+    Database_Execute(query);
+
+    PlayerData[playerid][pBankBalance] = 0;
+    PlayerData[playerid][pPaycheck] = 0;
+    EconomyData[playerid][eLoaded] = true;
+    return 1;
+}
+
+stock Economy_OnPlayerLogin(playerid)
+{
+    if(!EconomyData[playerid][eLoaded])
+    {
+        Economy_OnAccountLoaded(playerid);
+    }
+
+    new message[144];
+    new buffer[32];
+    Economy_FormatMoney(PlayerData[playerid][pBankBalance], buffer, sizeof(buffer));
+    format(message, sizeof(message), "Saldo bankowe: %s$ | Czek oczekujacy: %d$", buffer, PlayerData[playerid][pPaycheck]);
+    SendClientMessage(playerid, COLOR_INFO, message);
+    SendClientMessage(playerid, COLOR_INFO, "Uzyj /saldo aby sprawdzic szczegoly bankowe.");
+    return 1;
+}
+
+stock Economy_OnPlayerDisconnect(playerid)
+{
+    if(PlayerData[playerid][pLogged])
+    {
+        Economy_SavePlayer(playerid);
+    }
+    Economy_ResetPlayer(playerid);
+    return 1;
+}
+
+stock Economy_OnPlayerSave(playerid)
+{
+    return Economy_SavePlayer(playerid);
+}
+
+stock Economy_SavePlayer(playerid)
+{
+    if(!EconomyData[playerid][eLoaded] || PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new query[256];
+    format(query, sizeof(query),
+        "REPLACE INTO account_finances (account_id, bank_balance, paycheck, updated_at) VALUES (%d, %d, %d, CURRENT_TIMESTAMP)",
+        PlayerData[playerid][pID], PlayerData[playerid][pBankBalance], PlayerData[playerid][pPaycheck]);
+    Database_Execute(query);
+    return 1;
+}
+
+stock Economy_OnPlayerSpawn(playerid)
+{
+    if(PlayerData[playerid][pLogged])
+    {
+        SendClientMessage(playerid, COLOR_INFO, "Pamietaj o banku: /wplac, /wyplac, /przelej, /saldo.");
+    }
+    return 1;
+}
+
+stock Economy_OnPlayerCommandText(playerid, cmdtext[])
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        return 0;
+    }
+
+    new command[16];
+
+    if(sscanf(cmdtext[1], "s[16]", command))
+    {
+        return 0;
+    }
+
+    if(!strcmp(command, "saldo", true))
+    {
+        Economy_ShowBalance(playerid);
+        return 1;
+    }
+
+    if(!strcmp(command, "wplac", true))
+    {
+        new amount;
+        if(sscanf(cmdtext[1], "s[16]i", command, amount))
+        {
+            SendClientMessage(playerid, COLOR_INFO, "Uzycie: /wplac [kwota]");
+            return 1;
+        }
+        Economy_Deposit(playerid, amount);
+        return 1;
+    }
+
+    if(!strcmp(command, "wyplac", true))
+    {
+        new amount;
+        if(sscanf(cmdtext[1], "s[16]i", command, amount))
+        {
+            SendClientMessage(playerid, COLOR_INFO, "Uzycie: /wyplac [kwota]");
+            return 1;
+        }
+        Economy_Withdraw(playerid, amount);
+        return 1;
+    }
+
+    if(!strcmp(command, "przelej", true))
+    {
+        new targetid, amount;
+        if(sscanf(cmdtext[1], "s[16]ii", command, targetid, amount))
+        {
+            SendClientMessage(playerid, COLOR_INFO, "Uzycie: /przelej [id] [kwota]");
+            return 1;
+        }
+        Economy_Transfer(playerid, targetid, amount);
+        return 1;
+    }
+
+    return 0;
+}
+
+stock Economy_ShowBalance(playerid)
+{
+    new balanceBuffer[32];
+    Economy_FormatMoney(PlayerData[playerid][pBankBalance], balanceBuffer, sizeof(balanceBuffer));
+
+    new message[160];
+    format(message, sizeof(message), "Stan konta: %s$ | Czek: %d$", balanceBuffer, PlayerData[playerid][pPaycheck]);
+    SendClientMessage(playerid, COLOR_INFO, message);
+    return 1;
+}
+
+stock Economy_Deposit(playerid, amount)
+{
+    if(amount <= 0)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Kwota musi byc wieksza od zera.");
+        return 0;
+    }
+
+    if(GetPlayerMoney(playerid) < amount)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie posiadasz tylu pieniedzy przy sobie.");
+        return 0;
+    }
+
+    GivePlayerMoney(playerid, -amount);
+    PlayerData[playerid][pBankBalance] += amount;
+    Economy_AddTransaction(playerid, "DEPOSIT", amount, PlayerData[playerid][pBankBalance], "Wplata gotowki");
+    Economy_SavePlayer(playerid);
+
+    new info[144];
+    format(info, sizeof(info), "Wplacono %d$ na konto bankowe.", amount);
+    SendClientMessage(playerid, COLOR_SUCCESS, info);
+    return 1;
+}
+
+stock Economy_Withdraw(playerid, amount)
+{
+    if(amount <= 0)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Kwota musi byc wieksza od zera.");
+        return 0;
+    }
+
+    if(PlayerData[playerid][pBankBalance] < amount)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie posiadasz tylu srodkow w banku.");
+        return 0;
+    }
+
+    PlayerData[playerid][pBankBalance] -= amount;
+    GivePlayerMoney(playerid, amount);
+    Economy_AddTransaction(playerid, "WITHDRAW", amount, PlayerData[playerid][pBankBalance], "Wyplata gotowki");
+    Economy_SavePlayer(playerid);
+
+    new info[144];
+    format(info, sizeof(info), "Wyplacono %d$ z konta bankowego.", amount);
+    SendClientMessage(playerid, COLOR_SUCCESS, info);
+    return 1;
+}
+
+stock Economy_Transfer(playerid, targetid, amount)
+{
+    if(playerid == targetid)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie mozesz wykonac przelewu do siebie.");
+        return 0;
+    }
+
+    if(!IsPlayerConnected(targetid) || !PlayerData[targetid][pLogged])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Wybrany gracz nie jest dostepny.");
+        return 0;
+    }
+
+    if(amount < ECONOMY_MIN_TRANSFER)
+    {
+        new info[144];
+        format(info, sizeof(info), "Minimalny przelew to %d$.", ECONOMY_MIN_TRANSFER);
+        SendClientMessage(playerid, COLOR_ERROR, info);
+        return 0;
+    }
+
+    if(amount > ECONOMY_MAX_TRANSFER)
+    {
+        new info[144];
+        format(info, sizeof(info), "Maksymalny pojedynczy przelew to %d$.", ECONOMY_MAX_TRANSFER);
+        SendClientMessage(playerid, COLOR_ERROR, info);
+        return 0;
+    }
+
+    if(PlayerData[playerid][pBankBalance] < amount)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie posiadasz tylu srodkow w banku.");
+        return 0;
+    }
+
+    PlayerData[playerid][pBankBalance] -= amount;
+    PlayerData[targetid][pBankBalance] += amount;
+
+    Economy_AddTransaction(playerid, "TRANSFER_OUT", amount, PlayerData[playerid][pBankBalance], "Przelew wychodzacy");
+    Economy_AddTransaction(targetid, "TRANSFER_IN", amount, PlayerData[targetid][pBankBalance], "Przelew przychodzacy");
+
+    Economy_SavePlayer(playerid);
+    Economy_SavePlayer(targetid);
+
+    new senderMessage[160];
+    new receiverMessage[160];
+
+    new targetName[MAX_PLAYER_NAME + 1];
+    new senderName[MAX_PLAYER_NAME + 1];
+    GetPlayerName(targetid, targetName, sizeof(targetName));
+    GetPlayerName(playerid, senderName, sizeof(senderName));
+
+    format(senderMessage, sizeof(senderMessage), "Przelano %d$ na konto gracza %s.", amount, targetName);
+    SendClientMessage(playerid, COLOR_SUCCESS, senderMessage);
+
+    format(receiverMessage, sizeof(receiverMessage), "Otrzymales przelew %d$ od %s.", amount, senderName);
+    SendClientMessage(targetid, COLOR_SUCCESS, receiverMessage);
+    return 1;
+}
+
+stock Economy_AddPaycheck(playerid, amount, const reason[])
+{
+    if(amount <= 0)
+    {
+        return 0;
+    }
+
+    PlayerData[playerid][pPaycheck] += amount;
+
+    if(PlayerData[playerid][pPaycheck] > ECONOMY_MAX_PAYCHECK)
+    {
+        PlayerData[playerid][pPaycheck] = ECONOMY_MAX_PAYCHECK;
+    }
+
+    new message[160];
+    format(message, sizeof(message), "Dodano do czeku %d$ (%s). Aktualny czek: %d$.", amount, reason, PlayerData[playerid][pPaycheck]);
+    SendClientMessage(playerid, COLOR_SUCCESS, message);
+    return 1;
+}
+
+stock Economy_AddTransaction(playerid, const type[], amount, newBalance, const description[])
+{
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new escapedDescription[128];
+    Database_Escape(description, escapedDescription, sizeof(escapedDescription));
+
+    new query[320];
+    format(query, sizeof(query),
+        "INSERT INTO transactions (account_id, type, amount, balance_after, description) VALUES (%d, '%s', %d, %d, '%s')",
+        PlayerData[playerid][pID], type, amount, newBalance, escapedDescription);
+    Database_Execute(query);
+    return 1;
+}
+
+stock Economy_FormatMoney(amount, output[], size)
+{
+    format(output, size, "%d", amount);
+    return 1;
+}
+
+public Economy_PaydayTick()
+{
+    for(new playerid = 0; playerid < MAX_PLAYERS; playerid++)
+    {
+        if(!IsPlayerConnected(playerid) || !PlayerData[playerid][pLogged])
+        {
+            continue;
+        }
+
+        Players_UpdateSession(playerid);
+
+        new payout = ECONOMY_BASE_SALARY + (PlayerData[playerid][pLevel] * ECONOMY_LEVEL_BONUS) + (PlayerData[playerid][pJobExperience] * ECONOMY_EXPERIENCE_BONUS) + PlayerData[playerid][pPaycheck];
+
+        if(payout <= 0)
+        {
+            continue;
+        }
+
+        PlayerData[playerid][pBankBalance] += payout;
+        PlayerData[playerid][pPaycheck] = 0;
+
+        Economy_AddTransaction(playerid, "PAYDAY", payout, PlayerData[playerid][pBankBalance], "Wyplata okresowa");
+        Economy_SavePlayer(playerid);
+
+        new message[160];
+        format(message, sizeof(message), "Wyplata: otrzymales %d$ (bank: %d$).", payout, PlayerData[playerid][pBankBalance]);
+        SendClientMessage(playerid, COLOR_INFO, message);
+    }
+    return 1;
+}
+

--- a/inc/gamemode/jobs.inc
+++ b/inc/gamemode/jobs.inc
@@ -1,0 +1,679 @@
+#if defined _JOBS_MODULE_INCLUDED
+    #endinput
+#endif
+#define _JOBS_MODULE_INCLUDED
+
+#define JOB_CENTER_X 1480.5162
+#define JOB_CENTER_Y -1771.2450
+#define JOB_CENTER_Z 18.7958
+#define JOB_CENTER_RANGE 3.5
+
+#define JOB_COURIER_VEHICLE_MODEL 482
+
+#define JOB_OBJECTIVE_NONE 0
+#define JOB_OBJECTIVE_COURIER_DELIVERY 1
+
+#define DIALOG_JOB_LIST 1500
+#define DIALOG_JOB_CONFIRM 1501
+
+enum E_JOB_IDS
+{
+    JOB_NONE,
+    JOB_COURIER,
+    JOB_MECHANIC,
+    JOB_COUNT
+};
+
+enum E_JOB_INFO
+{
+    jobName[32],
+    jobDescription[144],
+    jobMinLevel,
+    jobBaseBonus
+};
+
+new JobInfo[JOB_COUNT][E_JOB_INFO] =
+{
+    {"Bezrobotny", "Brak dodatkowych benefitow.", 1, 0},
+    {"Kurier", "Dostarczaj paczki do roznych czesci miasta. Kazda dostawa zwieksza twoje doswiadczenie.", 1, 350},
+    {"Mechanik", "Serwisuj pojazdy graczy. Uzyj /napraw [id] aby naprawic pojazd klienta.", 2, 400}
+};
+
+enum E_JOB_RUNTIME
+{
+    bool:jOnDuty,
+    jVehicle,
+    jObjective,
+    jDeliveries,
+    Float:jTargetX,
+    Float:jTargetY,
+    Float:jTargetZ
+};
+
+new JobRuntime[MAX_PLAYERS][E_JOB_RUNTIME];
+new JobDialogSelection[MAX_PLAYERS];
+
+new gJobCenterPickup = -1;
+new Text3D:gJobCenterLabel = Text3D:INVALID_3DTEXT_ID;
+
+new Float:gCourierPoints[][3] =
+{
+    {2132.1470, -1151.6403, 24.0547},
+    {1013.8136, -927.4852, 42.1797},
+    {1588.4121, -1683.2050, 6.2188},
+    {2472.3186, -1539.4280, 23.8359},
+    {211.5985, -178.2676, 1.5781},
+    {-2154.5969, -2460.1433, 30.6250},
+    {2765.3149, 1284.5260, 10.8203}
+};
+
+forward Economy_AddPaycheck(playerid, amount, const reason[]);
+
+forward Jobs_Init();
+forward Jobs_Shutdown();
+forward Jobs_OnAccountLoaded(playerid);
+forward Jobs_OnAccountRegistered(playerid);
+forward Jobs_OnPlayerLogin(playerid);
+forward Jobs_OnPlayerDisconnect(playerid);
+forward Jobs_OnPlayerSpawn(playerid);
+forward Jobs_OnPlayerCommandText(playerid, cmdtext[]);
+forward Jobs_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+forward Jobs_OnPlayerEnterCheckpoint(playerid);
+forward Jobs_OnVehicleDeath(vehicleid, killerid);
+forward Jobs_OnPlayerExitVehicle(playerid, vehicleid);
+forward Jobs_OnPlayerStateChange(playerid, newstate, oldstate);
+forward Jobs_OnPlayerPickUpPickup(playerid, pickupid);
+forward Jobs_GetJobName(jobid, output[], size);
+forward Jobs_OnPlayerSave(playerid);
+
+stock Jobs_Init()
+{
+    gJobCenterPickup = CreatePickup(1239, 23, JOB_CENTER_X, JOB_CENTER_Y, JOB_CENTER_Z);
+    gJobCenterLabel = Create3DTextLabel("Urzad pracy\nWpisz /praca", COLOR_WHITE, JOB_CENTER_X, JOB_CENTER_Y, JOB_CENTER_Z + 1.0, 25.0, 0, 0);
+    Core_Log("[Jobs] Zainicjalizowano urzad pracy.");
+    return 1;
+}
+
+stock Jobs_Shutdown()
+{
+    if(gJobCenterPickup != -1)
+    {
+        DestroyPickup(gJobCenterPickup);
+        gJobCenterPickup = -1;
+    }
+
+    if(gJobCenterLabel != Text3D:INVALID_3DTEXT_ID)
+    {
+        Delete3DTextLabel(gJobCenterLabel);
+        gJobCenterLabel = Text3D:INVALID_3DTEXT_ID;
+    }
+
+    for(new i = 0; i < MAX_PLAYERS; i++)
+    {
+        Jobs_StopDuty(i, true);
+    }
+
+    Core_Log("[Jobs] Zamknieto modul prac.");
+    return 1;
+}
+
+stock Jobs_ResetRuntime(playerid)
+{
+    JobRuntime[playerid][jOnDuty] = false;
+    JobRuntime[playerid][jVehicle] = 0;
+    JobRuntime[playerid][jObjective] = JOB_OBJECTIVE_NONE;
+    JobRuntime[playerid][jDeliveries] = 0;
+    JobRuntime[playerid][jTargetX] = 0.0;
+    JobRuntime[playerid][jTargetY] = 0.0;
+    JobRuntime[playerid][jTargetZ] = 0.0;
+    JobDialogSelection[playerid] = JOB_NONE;
+    return 1;
+}
+
+stock Jobs_OnAccountLoaded(playerid)
+{
+    Jobs_ResetRuntime(playerid);
+
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new query[256];
+    format(query, sizeof(query), "SELECT job_id, job_experience FROM account_jobs WHERE account_id=%d", PlayerData[playerid][pID]);
+
+    new DBResult:result = db_query(gDatabaseHandle, query);
+
+    if(result && db_num_rows(result) > 0)
+    {
+        db_next_row(result);
+        PlayerData[playerid][pJobID] = Database_FetchInt(result, "job_id");
+        PlayerData[playerid][pJobExperience] = Database_FetchInt(result, "job_experience");
+    }
+    else
+    {
+        if(result)
+        {
+            db_free_result(result);
+        }
+
+        format(query, sizeof(query), "INSERT INTO account_jobs (account_id, job_id, job_experience) VALUES (%d, %d, %d)", PlayerData[playerid][pID], JOB_NONE, 0);
+        Database_Execute(query);
+        PlayerData[playerid][pJobID] = JOB_NONE;
+        PlayerData[playerid][pJobExperience] = 0;
+        return 1;
+    }
+
+    if(result)
+    {
+        db_free_result(result);
+    }
+
+    return 1;
+}
+
+stock Jobs_OnAccountRegistered(playerid)
+{
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new query[256];
+    format(query, sizeof(query), "INSERT INTO account_jobs (account_id, job_id, job_experience) VALUES (%d, %d, %d)", PlayerData[playerid][pID], JOB_NONE, 0);
+    Database_Execute(query);
+    PlayerData[playerid][pJobID] = JOB_NONE;
+    PlayerData[playerid][pJobExperience] = 0;
+    return 1;
+}
+
+stock Jobs_OnPlayerLogin(playerid)
+{
+    new jobName[32];
+    Jobs_GetJobName(PlayerData[playerid][pJobID], jobName, sizeof(jobName));
+
+    new message[160];
+    format(message, sizeof(message), "Twoja praca: %s (doswiadczenie: %d).", jobName, PlayerData[playerid][pJobExperience]);
+    SendClientMessage(playerid, COLOR_INFO, message);
+    return 1;
+}
+
+stock Jobs_OnPlayerDisconnect(playerid)
+{
+    Jobs_StopDuty(playerid, true);
+    return 1;
+}
+
+stock Jobs_OnPlayerSpawn(playerid)
+{
+    Jobs_StopDuty(playerid, false);
+    return 1;
+}
+
+stock Jobs_OnPlayerSave(playerid)
+{
+    return Jobs_SavePlayer(playerid);
+}
+
+stock Jobs_OnPlayerCommandText(playerid, cmdtext[])
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        return 0;
+    }
+
+    new command[16];
+    if(sscanf(cmdtext[1], "s[16]", command))
+    {
+        return 0;
+    }
+
+    if(!strcmp(command, "praca", true))
+    {
+        Jobs_ShowJobMenu(playerid);
+        return 1;
+    }
+
+    if(!strcmp(command, "duty", true))
+    {
+        Jobs_StartDuty(playerid);
+        return 1;
+    }
+
+    if(!strcmp(command, "koniecduty", true))
+    {
+        Jobs_StopDuty(playerid, false);
+        SendClientMessage(playerid, COLOR_INFO, "Zakonczono dyzur.");
+        return 1;
+    }
+
+    if(!strcmp(command, "napraw", true))
+    {
+        new targetid;
+        if(sscanf(cmdtext[1], "s[16]i", command, targetid))
+        {
+            SendClientMessage(playerid, COLOR_INFO, "Uzycie: /napraw [id gracza]");
+            return 1;
+        }
+        Jobs_HandleMechanicRepair(playerid, targetid);
+        return 1;
+    }
+
+    return 0;
+}
+
+stock Jobs_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
+{
+    switch(dialogid)
+    {
+        case DIALOG_JOB_LIST:
+        {
+            if(!response)
+            {
+                return 1;
+            }
+
+            if(listitem < 0 || listitem >= JOB_COUNT)
+            {
+                return 1;
+            }
+
+            JobDialogSelection[playerid] = listitem;
+            Jobs_ShowJobConfirmation(playerid, listitem);
+            return 1;
+        }
+        case DIALOG_JOB_CONFIRM:
+        {
+            if(!response)
+            {
+                return 1;
+            }
+
+            new jobid = JobDialogSelection[playerid];
+            if(jobid < 0 || jobid >= JOB_COUNT)
+            {
+                return 1;
+            }
+
+            Jobs_AssignJob(playerid, jobid);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+stock Jobs_OnPlayerEnterCheckpoint(playerid)
+{
+    if(!JobRuntime[playerid][jOnDuty])
+    {
+        return 0;
+    }
+
+    if(JobRuntime[playerid][jObjective] == JOB_OBJECTIVE_COURIER_DELIVERY)
+    {
+        if(IsPlayerInRangeOfPoint(playerid, 4.0, JobRuntime[playerid][jTargetX], JobRuntime[playerid][jTargetY], JobRuntime[playerid][jTargetZ]))
+        {
+            DisablePlayerCheckpoint(playerid);
+            JobRuntime[playerid][jDeliveries]++;
+
+            new payout = JobInfo[JOB_COURIER][jobBaseBonus] + (JobRuntime[playerid][jDeliveries] * 25);
+            Economy_AddPaycheck(playerid, payout, "Kurier - dostawa");
+            PlayerData[playerid][pJobExperience]++;
+            Jobs_LogJobAction(playerid, PlayerData[playerid][pJobID], "Dostawa paczki", payout);
+            Jobs_SavePlayer(playerid);
+            Jobs_AssignCourierDelivery(playerid);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+stock Jobs_OnVehicleDeath(vehicleid, killerid)
+{
+    for(new playerid = 0; playerid < MAX_PLAYERS; playerid++)
+    {
+        if(JobRuntime[playerid][jVehicle] == vehicleid && JobRuntime[playerid][jOnDuty])
+        {
+            Jobs_StopDuty(playerid, true);
+            SendClientMessage(playerid, COLOR_WARNING, "Twoj pojazd sluzbowy zostal zniszczony. Dyzur zostal zakonczony.");
+            return 1;
+        }
+    }
+    return 0;
+}
+
+stock Jobs_OnPlayerExitVehicle(playerid, vehicleid)
+{
+    if(JobRuntime[playerid][jOnDuty] && JobRuntime[playerid][jVehicle] == vehicleid)
+    {
+        SendClientMessage(playerid, COLOR_WARNING, "Pozostaw pojazd sluzbowy w bezpiecznym miejscu lub zakoncz dyzur /koniecduty.");
+        return 1;
+    }
+    return 0;
+}
+
+stock Jobs_OnPlayerStateChange(playerid, newstate, oldstate)
+{
+    if(newstate == PLAYER_STATE_ONFOOT && oldstate == PLAYER_STATE_DRIVER)
+    {
+        if(JobRuntime[playerid][jOnDuty] && JobRuntime[playerid][jVehicle] != 0)
+        {
+            SendClientMessage(playerid, COLOR_INFO, "Pamietaj o zabezpieczeniu pojazdu sluzbowego.");
+        }
+    }
+    return 1;
+}
+
+stock Jobs_OnPlayerPickUpPickup(playerid, pickupid)
+{
+    if(pickupid == gJobCenterPickup)
+    {
+        Jobs_ShowJobMenu(playerid);
+        return 1;
+    }
+    return 0;
+}
+
+stock Jobs_GetJobName(jobid, output[], size)
+{
+    if(jobid < 0 || jobid >= JOB_COUNT)
+    {
+        jobid = JOB_NONE;
+    }
+
+    format(output, size, "%s", JobInfo[jobid][jobName]);
+    return 1;
+}
+
+stock Jobs_ShowJobMenu(playerid)
+{
+    new list[512];
+    list[0] = '\0';
+
+    for(new i = 1; i < JOB_COUNT; i++)
+    {
+        new line[96];
+        format(line, sizeof(line), "%s\tPoziom %d\n", JobInfo[i][jobName], JobInfo[i][jobMinLevel]);
+        strcat(list, line);
+    }
+
+    ShowPlayerDialog(playerid, DIALOG_JOB_LIST, DIALOG_STYLE_TABLIST_HEADERS, "Dostepne prace", list, "Wybierz", "Anuluj");
+    return 1;
+}
+
+stock Jobs_ShowJobConfirmation(playerid, jobid)
+{
+    if(jobid < 0 || jobid >= JOB_COUNT)
+    {
+        return 0;
+    }
+
+    new description[256];
+    format(description, sizeof(description), "%s\nWymagany poziom: %d\nPremia bazowa: %d$", JobInfo[jobid][jobDescription], JobInfo[jobid][jobMinLevel], JobInfo[jobid][jobBaseBonus]);
+    ShowPlayerDialog(playerid, DIALOG_JOB_CONFIRM, DIALOG_STYLE_MSGBOX, JobInfo[jobid][jobName], description, "Potwierdz", "Wstecz");
+    return 1;
+}
+
+stock Jobs_AssignJob(playerid, jobid)
+{
+    if(jobid < 0 || jobid >= JOB_COUNT)
+    {
+        return 0;
+    }
+
+    if(PlayerData[playerid][pLevel] < JobInfo[jobid][jobMinLevel])
+    {
+        new info[144];
+        format(info, sizeof(info), "Ta praca wymaga poziomu %d.", JobInfo[jobid][jobMinLevel]);
+        SendClientMessage(playerid, COLOR_ERROR, info);
+        return 0;
+    }
+
+    PlayerData[playerid][pJobID] = jobid;
+    PlayerData[playerid][pJobExperience] = 0;
+    Jobs_SavePlayer(playerid);
+
+    new jobName[32];
+    Jobs_GetJobName(jobid, jobName, sizeof(jobName));
+
+    new info[160];
+    format(info, sizeof(info), "Twoja nowa praca to %s. Wpisz /duty aby rozpoczac dyzur.", jobName);
+    SendClientMessage(playerid, COLOR_SUCCESS, info);
+    return 1;
+}
+
+stock Jobs_StartDuty(playerid)
+{
+    if(JobRuntime[playerid][jOnDuty])
+    {
+        SendClientMessage(playerid, COLOR_WARNING, "Juz pelnisz dyzur.");
+        return 0;
+    }
+
+    switch(PlayerData[playerid][pJobID])
+    {
+        case JOB_NONE:
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Najpierw wybierz prace w urzedzie.");
+            return 0;
+        }
+        case JOB_COURIER:
+        {
+            Jobs_StartCourierDuty(playerid);
+            return 1;
+        }
+        case JOB_MECHANIC:
+        {
+            Jobs_StartMechanicDuty(playerid);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+stock Jobs_StopDuty(playerid, bool:force)
+{
+    if(!JobRuntime[playerid][jOnDuty] && !force)
+    {
+        return 0;
+    }
+
+    if(JobRuntime[playerid][jVehicle] != 0)
+    {
+        Jobs_DestroyJobVehicle(playerid);
+    }
+
+    if(JobRuntime[playerid][jObjective] != JOB_OBJECTIVE_NONE)
+    {
+        DisablePlayerCheckpoint(playerid);
+    }
+
+    Jobs_ResetRuntime(playerid);
+    return 1;
+}
+
+stock Jobs_StartCourierDuty(playerid)
+{
+    Jobs_DestroyJobVehicle(playerid);
+
+    new vehicleid = CreateVehicle(JOB_COURIER_VEHICLE_MODEL, 1475.8975, -1768.2546, 18.7958, 270.0, 3, 3, 0);
+    if(vehicleid == 0)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie udalo sie przydzielic pojazdu sluzbowego.");
+        return 0;
+    }
+    JobRuntime[playerid][jVehicle] = vehicleid;
+    JobRuntime[playerid][jOnDuty] = true;
+    JobRuntime[playerid][jObjective] = JOB_OBJECTIVE_NONE;
+    JobRuntime[playerid][jDeliveries] = 0;
+
+    if(IsPlayerConnected(playerid))
+    {
+        PutPlayerInVehicle(playerid, vehicleid, 0);
+    }
+
+    SendClientMessage(playerid, COLOR_INFO, "Rozpoczales dyzur kuriera. Dostarcz paczki do wskazanych punktow.");
+    Jobs_AssignCourierDelivery(playerid);
+    return 1;
+}
+
+stock Jobs_AssignCourierDelivery(playerid)
+{
+    if(!JobRuntime[playerid][jOnDuty])
+    {
+        return 0;
+    }
+
+    new index = random(sizeof(gCourierPoints));
+    JobRuntime[playerid][jObjective] = JOB_OBJECTIVE_COURIER_DELIVERY;
+    JobRuntime[playerid][jTargetX] = gCourierPoints[index][0];
+    JobRuntime[playerid][jTargetY] = gCourierPoints[index][1];
+    JobRuntime[playerid][jTargetZ] = gCourierPoints[index][2];
+
+    SetPlayerCheckpoint(playerid, JobRuntime[playerid][jTargetX], JobRuntime[playerid][jTargetY], JobRuntime[playerid][jTargetZ], 3.0);
+
+    new info[160];
+    format(info, sizeof(info), "Nowa dostawa. Udaj sie do punktu %d.", index + 1);
+    SendClientMessage(playerid, COLOR_INFO, info);
+    return 1;
+}
+
+stock Jobs_StartMechanicDuty(playerid)
+{
+    JobRuntime[playerid][jOnDuty] = true;
+    JobRuntime[playerid][jObjective] = JOB_OBJECTIVE_NONE;
+    JobRuntime[playerid][jDeliveries] = 0;
+    SendClientMessage(playerid, COLOR_INFO, "Rozpoczales dyzur mechanika. Uzyj /napraw [id] aby pomoc klientom.");
+    return 1;
+}
+
+stock Jobs_HandleMechanicRepair(playerid, targetid)
+{
+    if(PlayerData[playerid][pJobID] != JOB_MECHANIC)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie posiadasz uprawnien mechanika.");
+        return 0;
+    }
+
+    if(!JobRuntime[playerid][jOnDuty])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Musisz byc na dyzurze aby wykonywac naprawy.");
+        return 0;
+    }
+
+    if(!IsPlayerConnected(targetid) || !PlayerData[targetid][pLogged])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Wybrany gracz nie jest dostepny.");
+        return 0;
+    }
+
+    if(!IsPlayerInRangeOfPoint(playerid, 8.0, JOB_CENTER_X, JOB_CENTER_Y, JOB_CENTER_Z) && !IsPlayerInRangeOfPlayer(playerid, targetid, 8.0))
+    {
+        SendClientMessage(playerid, COLOR_WARNING, "Musisz znajdowac sie blisko klienta.");
+        return 0;
+    }
+
+    if(!IsPlayerInAnyVehicle(targetid))
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Klient nie znajduje sie w pojezdzie.");
+        return 0;
+    }
+
+    new vehicleid = GetPlayerVehicleID(targetid);
+    if(vehicleid == 0)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie znaleziono pojazdu klienta.");
+        return 0;
+    }
+
+    new Float:health;
+    GetVehicleHealth(vehicleid, health);
+
+    if(health >= 1000.0)
+    {
+        SendClientMessage(playerid, COLOR_WARNING, "Pojazd nie wymaga naprawy.");
+        return 0;
+    }
+
+    new cost = JobInfo[JOB_MECHANIC][jobBaseBonus];
+
+    if(GetPlayerMoney(targetid) < cost)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Klient nie posiada wystarczajacej ilosci gotowki.");
+        return 0;
+    }
+
+    GivePlayerMoney(targetid, -cost);
+    RepairVehicle(vehicleid);
+    Economy_AddPaycheck(playerid, cost, "Mechanik - naprawa");
+    PlayerData[playerid][pJobExperience] += 2;
+    Jobs_LogJobAction(playerid, PlayerData[playerid][pJobID], "Naprawa pojazdu", cost);
+    Jobs_SavePlayer(playerid);
+
+    new clientName[MAX_PLAYER_NAME + 1];
+    new mechanicName[MAX_PLAYER_NAME + 1];
+    GetPlayerName(targetid, clientName, sizeof(clientName));
+    GetPlayerName(playerid, mechanicName, sizeof(mechanicName));
+
+    new info[160];
+    format(info, sizeof(info), "Naprawiles pojazd gracza %s i otrzymales %d$ do czeku.", clientName, cost);
+    SendClientMessage(playerid, COLOR_SUCCESS, info);
+
+    format(info, sizeof(info), "Mechanik %s naprawil twoj pojazd za %d$.", mechanicName, cost);
+    SendClientMessage(targetid, COLOR_INFO, info);
+    return 1;
+}
+
+stock Jobs_SavePlayer(playerid)
+{
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new query[256];
+    format(query, sizeof(query),
+        "REPLACE INTO account_jobs (account_id, job_id, job_experience, updated_at) VALUES (%d, %d, %d, CURRENT_TIMESTAMP)",
+        PlayerData[playerid][pID], PlayerData[playerid][pJobID], PlayerData[playerid][pJobExperience]);
+    Database_Execute(query);
+    return 1;
+}
+
+stock Jobs_DestroyJobVehicle(playerid)
+{
+    if(JobRuntime[playerid][jVehicle] != 0)
+    {
+        DestroyVehicle(JobRuntime[playerid][jVehicle]);
+        JobRuntime[playerid][jVehicle] = 0;
+    }
+    return 1;
+}
+
+stock Jobs_LogJobAction(playerid, jobid, const action[], payout)
+{
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        return 0;
+    }
+
+    new escapedAction[128];
+    Database_Escape(action, escapedAction, sizeof(escapedAction));
+
+    new query[256];
+    format(query, sizeof(query),
+        "INSERT INTO job_logs (account_id, job_id, action, payout) VALUES (%d, %d, '%s', %d)",
+        PlayerData[playerid][pID], jobid, escapedAction, payout);
+    Database_Execute(query);
+    return 1;
+}
+
+stock bool:IsPlayerInRangeOfPlayer(playerid, targetid, Float:range)
+{
+    new Float:x1, Float:y1, Float:z1;
+    new Float:x2, Float:y2, Float:z2;
+    GetPlayerPos(playerid, x1, y1, z1);
+    GetPlayerPos(targetid, x2, y2, z2);
+    return floatsqroot((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2)) <= range;
+}
+

--- a/inc/gamemode/players.inc
+++ b/inc/gamemode/players.inc
@@ -1,0 +1,539 @@
+#if defined _PLAYERS_MODULE_INCLUDED
+    #endinput
+#endif
+#define _PLAYERS_MODULE_INCLUDED
+
+#define DIALOG_LOGIN 1000
+#define DIALOG_REGISTER 1001
+#define DIALOG_CHANGEPASS 1002
+
+forward Economy_OnAccountLoaded(playerid);
+forward Economy_OnAccountRegistered(playerid);
+forward Economy_OnPlayerLogin(playerid);
+forward Economy_OnPlayerDisconnect(playerid);
+forward Economy_OnPlayerSave(playerid);
+forward Economy_OnPlayerSpawn(playerid);
+forward Economy_OnPlayerCommandText(playerid, cmdtext[]);
+
+forward Jobs_OnAccountLoaded(playerid);
+forward Jobs_OnAccountRegistered(playerid);
+forward Jobs_OnPlayerLogin(playerid);
+forward Jobs_OnPlayerDisconnect(playerid);
+forward Jobs_OnPlayerSpawn(playerid);
+forward Jobs_OnPlayerCommandText(playerid, cmdtext[]);
+forward Jobs_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+forward Jobs_OnPlayerStateChange(playerid, newstate, oldstate);
+forward Jobs_OnPlayerSave(playerid);
+forward Jobs_GetJobName(jobid, output[], size);
+forward Players_Init();
+forward Players_Shutdown();
+forward Players_OnPlayerConnect(playerid);
+forward Players_OnPlayerDisconnect(playerid, reason);
+forward Players_OnPlayerRequestClass(playerid, classid);
+forward Players_OnPlayerSpawn(playerid);
+forward Players_OnPlayerCommandText(playerid, cmdtext[]);
+forward Players_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+forward Players_OnPlayerStateChange(playerid, newstate, oldstate);
+forward Players_SaveAccount(playerid);
+forward Players_LoadAccount(playerid);
+forward Players_LoginPlayer(playerid, const password[]);
+forward Players_RegisterPlayer(playerid, const password[]);
+forward Players_ShowLoginDialog(playerid);
+forward Players_ShowRegisterDialog(playerid);
+forward Players_SpawnPlayer(playerid);
+forward Players_UpdateSession(playerid);
+forward Players_GenerateSalt(output[], length);
+forward Players_LogEvent(playerid, const level[], const message[]);
+
+stock Players_Init()
+{
+    UsePlayerPedAnims();
+    EnableInteriorEnterExits();
+    SetWorldTime(12);
+    SetNameTagDrawDistance(50.0);
+    AllowInteriorWeapons(0);
+    return 1;
+}
+
+stock Players_Shutdown()
+{
+    for(new playerid = 0; playerid < MAX_PLAYERS; playerid++)
+    {
+        if(IsPlayerConnected(playerid) && PlayerData[playerid][pLogged])
+        {
+            Players_SaveAccount(playerid);
+        }
+    }
+    return 1;
+}
+
+stock Players_OnPlayerConnect(playerid)
+{
+    Core_ResetPlayerData(playerid);
+    PlayerData[playerid][pConnected] = true;
+
+    new name[MAX_PLAYER_NAME + 1];
+    GetPlayerName(playerid, name, sizeof(name));
+
+    new ip[16];
+    GetPlayerIp(playerid, ip, sizeof(ip));
+    format(PlayerData[playerid][pIP], sizeof(PlayerData[playerid][pIP]), "%s", ip);
+
+    new message[144];
+    format(message, sizeof(message), "Witaj %s na %s v%s", name, SERVER_NAME, SERVER_VERSION);
+    SendClientMessage(playerid, COLOR_INFO, message);
+
+    Players_LoadAccount(playerid);
+    TogglePlayerSpectating(playerid, true);
+    Players_ShowLoginDialog(playerid);
+    return 1;
+}
+
+stock Players_OnPlayerDisconnect(playerid, reason)
+{
+    if(PlayerData[playerid][pLogged])
+    {
+        Players_SaveAccount(playerid);
+    }
+    Economy_OnPlayerDisconnect(playerid);
+    Jobs_OnPlayerDisconnect(playerid);
+    Core_ResetPlayerData(playerid);
+    return 1;
+}
+
+stock Players_OnPlayerRequestClass(playerid, classid)
+{
+    SetPlayerInterior(playerid, 0);
+    SetPlayerVirtualWorld(playerid, playerid + 1);
+    SetPlayerPos(playerid, 1958.3783, 1343.1572, 15.3746);
+    SetPlayerCameraPos(playerid, 1958.3783, 1348.1572, 17.8746);
+    SetPlayerCameraLookAt(playerid, 1958.3783, 1343.1572, 15.3746);
+    return 1;
+}
+
+stock Players_OnPlayerSpawn(playerid)
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        Players_ShowLoginDialog(playerid);
+        return 0;
+    }
+    Players_SpawnPlayer(playerid);
+    Economy_OnPlayerSpawn(playerid);
+    Jobs_OnPlayerSpawn(playerid);
+    return 1;
+}
+
+stock Players_OnPlayerCommandText(playerid, cmdtext[])
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Musisz byc zalogowany aby korzystac z komend.");
+        return 1;
+    }
+
+    if(Economy_OnPlayerCommandText(playerid, cmdtext))
+    {
+        return 1;
+    }
+
+    if(Jobs_OnPlayerCommandText(playerid, cmdtext))
+    {
+        return 1;
+    }
+
+    if(!strcmp(cmdtext, "/stats", true))
+    {
+        new message[256];
+        new jobName[32];
+        Jobs_GetJobName(PlayerData[playerid][pJobID], jobName, sizeof(jobName));
+
+        format(message, sizeof(message), "Poziom: %d | Gotowka: %d$ | Bank: %d$", PlayerData[playerid][pLevel], PlayerData[playerid][pMoney], PlayerData[playerid][pBankBalance]);
+        SendClientMessage(playerid, COLOR_INFO, message);
+        format(message, sizeof(message), "Praca: %s | Doswiadczenie: %d | Skin: %d", jobName, PlayerData[playerid][pJobExperience], PlayerData[playerid][pSkin]);
+        SendClientMessage(playerid, COLOR_INFO, message);
+        format(message, sizeof(message), "Ostatnie logowanie: %s | IP: %s", PlayerData[playerid][pLastLogin], PlayerData[playerid][pIP]);
+        SendClientMessage(playerid, COLOR_INFO, message);
+        return 1;
+    }
+
+    if(!strcmp(cmdtext, "/changepass", true))
+    {
+        ShowPlayerDialog(playerid, DIALOG_CHANGEPASS, DIALOG_STYLE_PASSWORD, "Zmiana hasla", "Podaj nowe haslo do konta", "Zapisz", "Anuluj");
+        return 1;
+    }
+
+    if(!strcmp(cmdtext, "/logout", true))
+    {
+        Players_SaveAccount(playerid);
+        SendClientMessage(playerid, COLOR_WARNING, "Wylogowales sie z konta.");
+        TogglePlayerSpectating(playerid, true);
+        PlayerData[playerid][pLogged] = false;
+        Players_ShowLoginDialog(playerid);
+        return 1;
+    }
+
+    return 0;
+}
+
+stock Players_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
+{
+    switch(dialogid)
+    {
+        case DIALOG_LOGIN:
+        {
+            if(!response)
+            {
+                Kick(playerid);
+                return 1;
+            }
+            if(strlen(inputtext) < 4)
+            {
+                SendClientMessage(playerid, COLOR_ERROR, "Haslo musi posiadac co najmniej 4 znaki.");
+                Players_ShowLoginDialog(playerid);
+                return 1;
+            }
+            Players_LoginPlayer(playerid, inputtext);
+            return 1;
+        }
+        case DIALOG_REGISTER:
+        {
+            if(!response)
+            {
+                Kick(playerid);
+                return 1;
+            }
+            if(strlen(inputtext) < 6)
+            {
+                SendClientMessage(playerid, COLOR_ERROR, "Haslo musi posiadac co najmniej 6 znakow.");
+                Players_ShowRegisterDialog(playerid);
+                return 1;
+            }
+            Players_RegisterPlayer(playerid, inputtext);
+            return 1;
+        }
+        case DIALOG_CHANGEPASS:
+        {
+            if(!response)
+            {
+                return 1;
+            }
+            if(strlen(inputtext) < 6)
+            {
+                SendClientMessage(playerid, COLOR_ERROR, "Haslo musi posiadac co najmniej 6 znakow.");
+                return 1;
+            }
+
+            new salt[MAX_ACCOUNT_SALT + 1];
+            Players_GenerateSalt(salt, sizeof(salt));
+
+            new hashed[129];
+            new saltedPassword[128];
+            format(saltedPassword, sizeof(saltedPassword), "%s%s", inputtext, salt);
+            WP_Hash(hashed, saltedPassword);
+
+            new name[MAX_PLAYER_NAME + 1];
+            GetPlayerName(playerid, name, sizeof(name));
+
+            new query[512];
+            format(query, sizeof(query), "UPDATE accounts SET password='%s', salt='%s' WHERE id=%d", hashed, salt, PlayerData[playerid][pID]);
+            Database_Execute(query);
+
+            format(PlayerData[playerid][pPassword], sizeof(PlayerData[playerid][pPassword]), "%s", hashed);
+            format(PlayerData[playerid][pSalt], sizeof(PlayerData[playerid][pSalt]), "%s", salt);
+
+            SendClientMessage(playerid, COLOR_SUCCESS, "Haslo zostalo pomyslnie zmienione.");
+
+            new logMessage[144];
+            format(logMessage, sizeof(logMessage), "Zmienil haslo na koncie.");
+            Players_LogEvent(playerid, "SECURITY", logMessage);
+            return 1;
+        }
+    }
+
+    if(Jobs_OnDialogResponse(playerid, dialogid, response, listitem, inputtext))
+    {
+        return 1;
+    }
+    return 0;
+}
+
+stock Players_OnPlayerStateChange(playerid, newstate, oldstate)
+{
+    Jobs_OnPlayerStateChange(playerid, newstate, oldstate);
+    if(newstate == PLAYER_STATE_DRIVER)
+    {
+        Players_UpdateSession(playerid);
+    }
+    return 1;
+}
+
+stock Players_SaveAccount(playerid)
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        return 0;
+    }
+
+    Players_UpdateSession(playerid);
+    PlayerData[playerid][pMoney] = GetPlayerMoney(playerid);
+    PlayerData[playerid][pSkin] = GetPlayerSkin(playerid);
+
+    new query[512];
+    format(query, sizeof(query), "UPDATE accounts SET level=%d, money=%d, skin=%d, spawn_x=%f, spawn_y=%f, spawn_z=%f, spawn_angle=%f, last_login='%s' WHERE id=%d",
+        PlayerData[playerid][pLevel], PlayerData[playerid][pMoney], PlayerData[playerid][pSkin],
+        Float:PlayerData[playerid][pSpawnX], Float:PlayerData[playerid][pSpawnY], Float:PlayerData[playerid][pSpawnZ],
+        Float:PlayerData[playerid][pSpawnAngle], PlayerData[playerid][pLastLogin], PlayerData[playerid][pID]);
+    Database_Execute(query);
+
+    new logMessage[144];
+    format(logMessage, sizeof(logMessage), "Zapisano dane konta.");
+    Players_LogEvent(playerid, "INFO", logMessage);
+    Economy_OnPlayerSave(playerid);
+    Jobs_OnPlayerSave(playerid);
+    return 1;
+}
+
+stock Players_LoadAccount(playerid)
+{
+    new name[MAX_PLAYER_NAME + 1];
+    GetPlayerName(playerid, name, sizeof(name));
+
+    new escapedName[2 * MAX_PLAYER_NAME + 1];
+    Database_Escape(name, escapedName, sizeof(escapedName));
+
+    new query[256];
+    format(query, sizeof(query), "SELECT * FROM accounts WHERE name='%s'", escapedName);
+
+    new DBResult:result = db_query(gDatabaseHandle, query);
+    if(!result)
+    {
+        return 0;
+    }
+
+    if(db_num_rows(result) > 0)
+    {
+        PlayerData[playerid][pRegistered] = true;
+        db_next_row(result);
+
+        PlayerData[playerid][pID] = Database_FetchInt(result, "id");
+        PlayerData[playerid][pLevel] = Database_FetchInt(result, "level");
+        PlayerData[playerid][pMoney] = Database_FetchInt(result, "money");
+        PlayerData[playerid][pSkin] = Database_FetchInt(result, "skin");
+
+        new Float:spawnX = Database_FetchFloat(result, "spawn_x");
+        new Float:spawnY = Database_FetchFloat(result, "spawn_y");
+        new Float:spawnZ = Database_FetchFloat(result, "spawn_z");
+        new Float:spawnA = Database_FetchFloat(result, "spawn_angle");
+
+        PlayerData[playerid][pSpawnX] = spawnX;
+        PlayerData[playerid][pSpawnY] = spawnY;
+        PlayerData[playerid][pSpawnZ] = spawnZ;
+        PlayerData[playerid][pSpawnAngle] = spawnA;
+        Database_FetchString(result, "password", PlayerData[playerid][pPassword], sizeof(PlayerData[playerid][pPassword]));
+        Database_FetchString(result, "salt", PlayerData[playerid][pSalt], sizeof(PlayerData[playerid][pSalt]));
+        Database_FetchString(result, "last_login", PlayerData[playerid][pLastLogin], sizeof(PlayerData[playerid][pLastLogin]));
+
+        new ip[16];
+        GetPlayerIp(playerid, ip, sizeof(ip));
+        new escapedIP[33];
+        Database_Escape(ip, escapedIP, sizeof(escapedIP));
+
+        format(query, sizeof(query), "UPDATE accounts SET ip='%s' WHERE id=%d", escapedIP, PlayerData[playerid][pID]);
+        Database_Execute(query);
+    }
+    else
+    {
+        PlayerData[playerid][pRegistered] = false;
+    }
+
+    db_free_result(result);
+
+    if(PlayerData[playerid][pRegistered])
+    {
+        Economy_OnAccountLoaded(playerid);
+        Jobs_OnAccountLoaded(playerid);
+    }
+    return 1;
+}
+
+stock Players_LoginPlayer(playerid, const password[])
+{
+    if(!PlayerData[playerid][pRegistered])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Twoje konto nie istnieje. Zarejestruj sie.");
+        Players_ShowRegisterDialog(playerid);
+        return 1;
+    }
+
+    if(PlayerData[playerid][pLoginAttempts] >= MAX_LOGIN_ATTEMPTS)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Przekroczono limit prob logowania. Polaczenie zostanie rozlaczone.");
+        Kick(playerid);
+        return 1;
+    }
+
+    new saltedPassword[128];
+    format(saltedPassword, sizeof(saltedPassword), "%s%s", password, PlayerData[playerid][pSalt]);
+
+    new hashed[129];
+    WP_Hash(hashed, saltedPassword);
+
+    if(strcmp(hashed, PlayerData[playerid][pPassword], false) != 0)
+    {
+        PlayerData[playerid][pLoginAttempts]++;
+        SendClientMessage(playerid, COLOR_ERROR, "Niepoprawne haslo. Sprobuj ponownie.");
+        Players_ShowLoginDialog(playerid);
+        return 1;
+    }
+
+    PlayerData[playerid][pLogged] = true;
+    PlayerData[playerid][pSessionStart] = gettime();
+
+    GivePlayerMoney(playerid, PlayerData[playerid][pMoney] - GetPlayerMoney(playerid));
+    SetSpawnInfo(playerid, 0, PlayerData[playerid][pSkin], Float:PlayerData[playerid][pSpawnX], Float:PlayerData[playerid][pSpawnY], Float:PlayerData[playerid][pSpawnZ], Float:PlayerData[playerid][pSpawnAngle], 0, 0, 0, 0, 0, 0);
+    TogglePlayerSpectating(playerid, false);
+    SpawnPlayer(playerid);
+
+    new message[144];
+    format(message, sizeof(message), "Zalogowales sie pomyslnie. Zycze milej gry!");
+    SendClientMessage(playerid, COLOR_SUCCESS, message);
+
+    new timestamp[32];
+    Core_FormatTime(timestamp, sizeof(timestamp));
+    format(PlayerData[playerid][pLastLogin], sizeof(PlayerData[playerid][pLastLogin]), "%s", timestamp);
+
+    new logMessage[144];
+    format(logMessage, sizeof(logMessage), "Zalogowal sie na serwer.");
+    Players_LogEvent(playerid, "LOGIN", logMessage);
+    Economy_OnPlayerLogin(playerid);
+    Jobs_OnPlayerLogin(playerid);
+    return 1;
+}
+
+stock Players_RegisterPlayer(playerid, const password[])
+{
+    if(PlayerData[playerid][pRegistered])
+    {
+        SendClientMessage(playerid, COLOR_WARNING, "Konto juz istnieje. Zaloguj sie.");
+        Players_ShowLoginDialog(playerid);
+        return 1;
+    }
+
+    new salt[MAX_ACCOUNT_SALT + 1];
+    Players_GenerateSalt(salt, sizeof(salt));
+
+    new saltedPassword[128];
+    format(saltedPassword, sizeof(saltedPassword), "%s%s", password, salt);
+
+    new hashed[129];
+    WP_Hash(hashed, saltedPassword);
+
+    new name[MAX_PLAYER_NAME + 1];
+    GetPlayerName(playerid, name, sizeof(name));
+
+    new escapedName[2 * MAX_PLAYER_NAME + 1];
+    Database_Escape(name, escapedName, sizeof(escapedName));
+
+    new ip[16];
+    GetPlayerIp(playerid, ip, sizeof(ip));
+    new escapedIP[33];
+    Database_Escape(ip, escapedIP, sizeof(escapedIP));
+
+    new query[512];
+    format(query, sizeof(query),
+        "INSERT INTO accounts (name, password, salt, level, money, skin, spawn_x, spawn_y, spawn_z, spawn_angle, ip, last_login) VALUES ('%s', '%s', '%s', %d, %d, %d, %f, %f, %f, %f, '%s', CURRENT_TIMESTAMP)",
+        escapedName, hashed, salt, PlayerData[playerid][pLevel], PlayerData[playerid][pMoney], PlayerData[playerid][pSkin],
+        Float:PlayerData[playerid][pSpawnX], Float:PlayerData[playerid][pSpawnY], Float:PlayerData[playerid][pSpawnZ], Float:PlayerData[playerid][pSpawnAngle], escapedIP);
+
+    Database_Execute(query);
+
+    PlayerData[playerid][pID] = db_last_insert_rowid(gDatabaseHandle);
+    PlayerData[playerid][pRegistered] = true;
+    format(PlayerData[playerid][pPassword], sizeof(PlayerData[playerid][pPassword]), "%s", hashed);
+    format(PlayerData[playerid][pSalt], sizeof(PlayerData[playerid][pSalt]), "%s", salt);
+
+    SendClientMessage(playerid, COLOR_SUCCESS, "Rejestracja przebiegla pomyslnie. Zaloguj sie.");
+    Players_ShowLoginDialog(playerid);
+
+    new logMessage[144];
+    format(logMessage, sizeof(logMessage), "Zarejestrowal nowe konto.");
+    Players_LogEvent(playerid, "REGISTER", logMessage);
+    Economy_OnAccountRegistered(playerid);
+    Jobs_OnAccountRegistered(playerid);
+    return 1;
+}
+
+stock Players_ShowLoginDialog(playerid)
+{
+    if(PlayerData[playerid][pRegistered])
+    {
+        ShowPlayerDialog(playerid, DIALOG_LOGIN, DIALOG_STYLE_PASSWORD, "Logowanie", "Podaj haslo aby sie zalogowac", "Zaloguj", "Wyjdz");
+    }
+    else
+    {
+        Players_ShowRegisterDialog(playerid);
+    }
+    return 1;
+}
+
+stock Players_ShowRegisterDialog(playerid)
+{
+    ShowPlayerDialog(playerid, DIALOG_REGISTER, DIALOG_STYLE_PASSWORD, "Rejestracja", "Podaj haslo aby utworzyc konto", "Zarejestruj", "Wyjdz");
+    return 1;
+}
+
+stock Players_SpawnPlayer(playerid)
+{
+    SetPlayerInterior(playerid, 0);
+    SetPlayerVirtualWorld(playerid, 0);
+    SetPlayerPos(playerid, Float:PlayerData[playerid][pSpawnX], Float:PlayerData[playerid][pSpawnY], Float:PlayerData[playerid][pSpawnZ]);
+    SetPlayerFacingAngle(playerid, Float:PlayerData[playerid][pSpawnAngle]);
+    SetCameraBehindPlayer(playerid);
+    PlayerData[playerid][pSpawnPrepared] = true;
+    return 1;
+}
+
+stock Players_UpdateSession(playerid)
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        return 0;
+    }
+    new now = gettime();
+    new played = now - PlayerData[playerid][pSessionStart];
+    if(played < 0) played = 0;
+    PlayerData[playerid][pPlayTime] += played;
+    PlayerData[playerid][pSessionStart] = now;
+    return 1;
+}
+
+stock Players_GenerateSalt(output[], length)
+{
+    static const characters[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    new charCount = sizeof(characters) - 1;
+    for(new i = 0; i < length - 1; i++)
+    {
+        output[i] = characters[random(charCount)];
+    }
+    output[length - 1] = '\0';
+    return 1;
+}
+
+stock Players_LogEvent(playerid, const level[], const message[])
+{
+    new name[MAX_PLAYER_NAME + 1];
+    GetPlayerName(playerid, name, sizeof(name));
+
+    new escapedName[2 * MAX_PLAYER_NAME + 1];
+    Database_Escape(name, escapedName, sizeof(escapedName));
+
+    new escapedMessage[256];
+    Database_Escape(message, escapedMessage, sizeof(escapedMessage));
+
+    new query[256];
+    format(query, sizeof(query), "INSERT INTO server_logs (level, message) VALUES ('%s', '[%s] %s')", level, escapedName, escapedMessage);
+    Database_Execute(query);
+    return 1;
+}
+

--- a/inc/gamemode/players.inc
+++ b/inc/gamemode/players.inc
@@ -25,6 +25,16 @@ forward Jobs_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[
 forward Jobs_OnPlayerStateChange(playerid, newstate, oldstate);
 forward Jobs_OnPlayerSave(playerid);
 forward Jobs_GetJobName(jobid, output[], size);
+forward Properties_OnPlayerConnect(playerid);
+forward Properties_OnPlayerDisconnect(playerid);
+forward Properties_OnAccountLoaded(playerid);
+forward Properties_OnAccountRegistered(playerid);
+forward Properties_OnPlayerLogin(playerid);
+forward Properties_OnPlayerSpawn(playerid);
+forward Properties_OnPlayerCommandText(playerid, cmdtext[]);
+forward Properties_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+forward Properties_OnPlayerSave(playerid);
+forward Properties_GetPropertyName(sqlid, output[], size);
 forward Players_Init();
 forward Players_Shutdown();
 forward Players_OnPlayerConnect(playerid);
@@ -72,6 +82,8 @@ stock Players_OnPlayerConnect(playerid)
     Core_ResetPlayerData(playerid);
     PlayerData[playerid][pConnected] = true;
 
+    Properties_OnPlayerConnect(playerid);
+
     new name[MAX_PLAYER_NAME + 1];
     GetPlayerName(playerid, name, sizeof(name));
 
@@ -97,6 +109,7 @@ stock Players_OnPlayerDisconnect(playerid, reason)
     }
     Economy_OnPlayerDisconnect(playerid);
     Jobs_OnPlayerDisconnect(playerid);
+    Properties_OnPlayerDisconnect(playerid);
     Core_ResetPlayerData(playerid);
     return 1;
 }
@@ -121,6 +134,7 @@ stock Players_OnPlayerSpawn(playerid)
     Players_SpawnPlayer(playerid);
     Economy_OnPlayerSpawn(playerid);
     Jobs_OnPlayerSpawn(playerid);
+    Properties_OnPlayerSpawn(playerid);
     return 1;
 }
 
@@ -142,6 +156,11 @@ stock Players_OnPlayerCommandText(playerid, cmdtext[])
         return 1;
     }
 
+    if(Properties_OnPlayerCommandText(playerid, cmdtext))
+    {
+        return 1;
+    }
+
     if(!strcmp(cmdtext, "/stats", true))
     {
         new message[256];
@@ -154,6 +173,22 @@ stock Players_OnPlayerCommandText(playerid, cmdtext[])
         SendClientMessage(playerid, COLOR_INFO, message);
         format(message, sizeof(message), "Ostatnie logowanie: %s | IP: %s", PlayerData[playerid][pLastLogin], PlayerData[playerid][pIP]);
         SendClientMessage(playerid, COLOR_INFO, message);
+
+        new propertyLine[256];
+        new propertyName[64];
+        if(PlayerData[playerid][pPropertyID] > 0)
+        {
+            if(!Properties_GetPropertyName(PlayerData[playerid][pPropertyID], propertyName, sizeof(propertyName)))
+            {
+                format(propertyName, sizeof(propertyName), "Brak");
+            }
+            format(propertyLine, sizeof(propertyLine), "Nieruchomosc: %s | Respawn: %s", propertyName, PlayerData[playerid][pPropertySpawn] ? "dom" : "miasto");
+        }
+        else
+        {
+            format(propertyLine, sizeof(propertyLine), "Nieruchomosc: Brak | Respawn: miasto");
+        }
+        SendClientMessage(playerid, COLOR_INFO, propertyLine);
         return 1;
     }
 
@@ -178,6 +213,11 @@ stock Players_OnPlayerCommandText(playerid, cmdtext[])
 
 stock Players_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 {
+    if(Properties_OnDialogResponse(playerid, dialogid, response, listitem, inputtext))
+    {
+        return 1;
+    }
+
     switch(dialogid)
     {
         case DIALOG_LOGIN:
@@ -280,10 +320,10 @@ stock Players_SaveAccount(playerid)
     PlayerData[playerid][pSkin] = GetPlayerSkin(playerid);
 
     new query[512];
-    format(query, sizeof(query), "UPDATE accounts SET level=%d, money=%d, skin=%d, spawn_x=%f, spawn_y=%f, spawn_z=%f, spawn_angle=%f, last_login='%s' WHERE id=%d",
+    format(query, sizeof(query), "UPDATE accounts SET level=%d, money=%d, skin=%d, spawn_x=%f, spawn_y=%f, spawn_z=%f, spawn_angle=%f, property_id=%d, property_spawn=%d, last_login='%s' WHERE id=%d",
         PlayerData[playerid][pLevel], PlayerData[playerid][pMoney], PlayerData[playerid][pSkin],
         Float:PlayerData[playerid][pSpawnX], Float:PlayerData[playerid][pSpawnY], Float:PlayerData[playerid][pSpawnZ],
-        Float:PlayerData[playerid][pSpawnAngle], PlayerData[playerid][pLastLogin], PlayerData[playerid][pID]);
+        Float:PlayerData[playerid][pSpawnAngle], PlayerData[playerid][pPropertyID], PlayerData[playerid][pPropertySpawn], PlayerData[playerid][pLastLogin], PlayerData[playerid][pID]);
     Database_Execute(query);
 
     new logMessage[144];
@@ -291,6 +331,7 @@ stock Players_SaveAccount(playerid)
     Players_LogEvent(playerid, "INFO", logMessage);
     Economy_OnPlayerSave(playerid);
     Jobs_OnPlayerSave(playerid);
+    Properties_OnPlayerSave(playerid);
     return 1;
 }
 
@@ -333,6 +374,8 @@ stock Players_LoadAccount(playerid)
         Database_FetchString(result, "password", PlayerData[playerid][pPassword], sizeof(PlayerData[playerid][pPassword]));
         Database_FetchString(result, "salt", PlayerData[playerid][pSalt], sizeof(PlayerData[playerid][pSalt]));
         Database_FetchString(result, "last_login", PlayerData[playerid][pLastLogin], sizeof(PlayerData[playerid][pLastLogin]));
+        PlayerData[playerid][pPropertyID] = Database_FetchInt(result, "property_id");
+        PlayerData[playerid][pPropertySpawn] = bool:Database_FetchInt(result, "property_spawn");
 
         new ip[16];
         GetPlayerIp(playerid, ip, sizeof(ip));
@@ -353,6 +396,7 @@ stock Players_LoadAccount(playerid)
     {
         Economy_OnAccountLoaded(playerid);
         Jobs_OnAccountLoaded(playerid);
+        Properties_OnAccountLoaded(playerid);
     }
     return 1;
 }
@@ -408,6 +452,7 @@ stock Players_LoginPlayer(playerid, const password[])
     Players_LogEvent(playerid, "LOGIN", logMessage);
     Economy_OnPlayerLogin(playerid);
     Jobs_OnPlayerLogin(playerid);
+    Properties_OnPlayerLogin(playerid);
     return 1;
 }
 
@@ -461,6 +506,7 @@ stock Players_RegisterPlayer(playerid, const password[])
     Players_LogEvent(playerid, "REGISTER", logMessage);
     Economy_OnAccountRegistered(playerid);
     Jobs_OnAccountRegistered(playerid);
+    Properties_OnAccountRegistered(playerid);
     return 1;
 }
 

--- a/inc/gamemode/properties.inc
+++ b/inc/gamemode/properties.inc
@@ -1,0 +1,948 @@
+#if defined _PROPERTIES_MODULE_INCLUDED
+    #endinput
+#endif
+#define _PROPERTIES_MODULE_INCLUDED
+
+#define MAX_PROPERTIES 64
+#define PROPERTY_INTERACTION_RANGE 3.5
+#define PROPERTY_VIRTUAL_BASE 2000
+
+#define DIALOG_PROPERTY_MENU 1800
+#define DIALOG_PROPERTY_CONFIRM 1801
+
+enum E_PROPERTY_DATA
+{
+    prSQLID,
+    prName[64],
+    prPrice,
+    prOwnerID,
+    prOwnerName[MAX_PLAYER_NAME + 1],
+    prLocked,
+    prInterior,
+    Float:prEnterX,
+    Float:prEnterY,
+    Float:prEnterZ,
+    Float:prExitX,
+    Float:prExitY,
+    Float:prExitZ,
+    prPickup,
+    prExitPickup,
+    Text3D:prLabel,
+    Text3D:prExitLabel,
+    prVirtualWorld
+};
+
+enum E_PROPERTY_OPTION
+{
+    PROPERTY_OPTION_NONE,
+    PROPERTY_OPTION_ENTER,
+    PROPERTY_OPTION_PREVIEW,
+    PROPERTY_OPTION_BUY,
+    PROPERTY_OPTION_SELL,
+    PROPERTY_OPTION_TOGGLE_LOCK,
+    PROPERTY_OPTION_SET_SPAWN
+};
+
+new PropertyData[MAX_PROPERTIES][E_PROPERTY_DATA];
+new PropertyCount = 0;
+
+new PropertyDialogOptions[MAX_PLAYERS][8];
+new PropertyDialogOptionCount[MAX_PLAYERS];
+new PropertyDialogPendingAction[MAX_PLAYERS];
+new PlayerPropertyTarget[MAX_PLAYERS];
+new PlayerPropertyInside[MAX_PLAYERS];
+
+forward Properties_Init();
+forward Properties_Shutdown();
+forward Properties_OnPlayerConnect(playerid);
+forward Properties_OnPlayerDisconnect(playerid);
+forward Properties_OnAccountLoaded(playerid);
+forward Properties_OnAccountRegistered(playerid);
+forward Properties_OnPlayerLogin(playerid);
+forward Properties_OnPlayerSpawn(playerid);
+forward Properties_OnPlayerCommandText(playerid, cmdtext[]);
+forward Properties_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+forward Properties_OnPlayerSave(playerid);
+forward Properties_OnPlayerPickUpPickup(playerid, pickupid);
+forward Properties_GetPropertyName(sqlid, output[], size);
+
+stock Properties_Init()
+{
+    for(new i = 0; i < MAX_PROPERTIES; i++)
+    {
+        Properties_ResetProperty(i);
+    }
+
+    for(new playerid = 0; playerid < MAX_PLAYERS; playerid++)
+    {
+        Properties_ResetPlayer(playerid);
+    }
+
+    PropertyCount = 0;
+    Properties_SeedDefaults();
+    Properties_LoadAll();
+
+    Core_Log("[Properties] Modul nieruchomosci zostal zainicjalizowany.");
+    return 1;
+}
+
+stock Properties_Shutdown()
+{
+    for(new i = 0; i < PropertyCount; i++)
+    {
+        Properties_DestroyVisual(i);
+    }
+    PropertyCount = 0;
+    Core_Log("[Properties] Modul nieruchomosci zostal zamkniety.");
+    return 1;
+}
+
+stock Properties_OnPlayerConnect(playerid)
+{
+    Properties_ResetPlayer(playerid);
+    return 1;
+}
+
+stock Properties_OnPlayerDisconnect(playerid)
+{
+    Properties_ResetPlayer(playerid);
+    return 1;
+}
+
+stock Properties_OnAccountLoaded(playerid)
+{
+    if(PlayerData[playerid][pPropertyID] <= 0)
+    {
+        return 1;
+    }
+
+    new index = Properties_FindBySQLID(PlayerData[playerid][pPropertyID]);
+    if(index != -1)
+    {
+        PropertyData[index][prOwnerID] = PlayerData[playerid][pID];
+        GetPlayerName(playerid, PropertyData[index][prOwnerName], sizeof(PropertyData[index][prOwnerName]));
+        Properties_RefreshVisual(index);
+    }
+    return 1;
+}
+
+stock Properties_OnAccountRegistered(playerid)
+{
+    PlayerData[playerid][pPropertyID] = 0;
+    PlayerData[playerid][pPropertySpawn] = false;
+    return 1;
+}
+
+stock Properties_OnPlayerLogin(playerid)
+{
+    if(PlayerData[playerid][pPropertyID] > 0)
+    {
+        new index = Properties_FindBySQLID(PlayerData[playerid][pPropertyID]);
+        if(index != -1)
+        {
+            GetPlayerName(playerid, PropertyData[index][prOwnerName], sizeof(PropertyData[index][prOwnerName]));
+            PropertyData[index][prOwnerID] = PlayerData[playerid][pID];
+            Properties_RefreshVisual(index);
+
+            new message[144];
+            format(message, sizeof(message), "Twoj dom: %s | Status drzwi: %s", PropertyData[index][prName], PropertyData[index][prLocked] ? "Zamkniete" : "Otwarte");
+            SendClientMessage(playerid, COLOR_INFO, message);
+        }
+        else
+        {
+            PlayerData[playerid][pPropertyID] = 0;
+            PlayerData[playerid][pPropertySpawn] = false;
+        }
+    }
+    return 1;
+}
+
+stock Properties_OnPlayerSpawn(playerid)
+{
+    if(!PlayerData[playerid][pPropertySpawn])
+    {
+        return 1;
+    }
+
+    if(PlayerData[playerid][pPropertyID] <= 0)
+    {
+        PlayerData[playerid][pPropertySpawn] = false;
+        return 1;
+    }
+
+    new index = Properties_FindBySQLID(PlayerData[playerid][pPropertyID]);
+    if(index == -1)
+    {
+        PlayerData[playerid][pPropertySpawn] = false;
+        return 1;
+    }
+
+    SetPlayerInterior(playerid, PropertyData[index][prInterior]);
+    SetPlayerVirtualWorld(playerid, PropertyData[index][prVirtualWorld]);
+    SetPlayerPos(playerid, Float:PropertyData[index][prExitX], Float:PropertyData[index][prExitY], Float:PropertyData[index][prExitZ]);
+    SetCameraBehindPlayer(playerid);
+    PlayerPropertyInside[playerid] = index;
+    PlayerPropertyTarget[playerid] = index;
+
+    new message[128];
+    format(message, sizeof(message), "Zrespawnowales w swoim domu: %s", PropertyData[index][prName]);
+    SendClientMessage(playerid, COLOR_INFO, message);
+    return 1;
+}
+
+stock Properties_OnPlayerCommandText(playerid, cmdtext[])
+{
+    if(!strcmp(cmdtext, "/dom", true))
+    {
+        new index = PlayerPropertyTarget[playerid];
+        if(index == -1)
+        {
+            index = Properties_FindNearest(playerid, PROPERTY_INTERACTION_RANGE);
+        }
+
+        if(index == -1)
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Nie ma nieruchomosci w poblizu.");
+            return 1;
+        }
+
+        PlayerPropertyTarget[playerid] = index;
+        Properties_ShowMenu(playerid, index);
+        return 1;
+    }
+
+    if(!strcmp(cmdtext, "/wyjdz", true))
+    {
+        if(PlayerPropertyInside[playerid] == -1)
+        {
+            SendClientMessage(playerid, COLOR_WARNING, "Nie znajdujesz sie w zadnej nieruchomosci.");
+            return 1;
+        }
+
+        Properties_Exit(playerid, PlayerPropertyInside[playerid]);
+        return 1;
+    }
+
+    if(!strcmp(cmdtext, "/kupdom", true))
+    {
+        new index = PlayerPropertyTarget[playerid];
+        if(index == -1)
+        {
+            index = Properties_FindNearest(playerid, PROPERTY_INTERACTION_RANGE);
+        }
+
+        if(index == -1)
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Nie ma nieruchomosci w poblizu.");
+            return 1;
+        }
+
+        Properties_AttemptBuy(playerid, index);
+        return 1;
+    }
+
+    return 0;
+}
+
+stock Properties_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
+{
+    switch(dialogid)
+    {
+        case DIALOG_PROPERTY_MENU:
+        {
+            if(!response)
+            {
+                return 1;
+            }
+
+            if(listitem < 0 || listitem >= PropertyDialogOptionCount[playerid])
+            {
+                return 1;
+            }
+
+            new action = PropertyDialogOptions[playerid][listitem];
+            PropertyDialogPendingAction[playerid] = action;
+
+            switch(action)
+            {
+                case PROPERTY_OPTION_BUY:
+                {
+                    Properties_ShowConfirm(playerid, "Czy na pewno chcesz kupic ten dom? Koszt zostanie pobrany z gotowki.");
+                    return 1;
+                }
+                case PROPERTY_OPTION_SELL:
+                {
+                    Properties_ShowConfirm(playerid, "Czy na pewno chcesz sprzedac dom? Otrzymasz 70 procent jego wartosci.");
+                    return 1;
+                }
+                default:
+                {
+                    Properties_ExecuteAction(playerid, action);
+                }
+            }
+            return 1;
+        }
+        case DIALOG_PROPERTY_CONFIRM:
+        {
+            if(response)
+            {
+                Properties_ExecuteAction(playerid, PropertyDialogPendingAction[playerid]);
+            }
+            PropertyDialogPendingAction[playerid] = PROPERTY_OPTION_NONE;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+stock Properties_OnPlayerSave(playerid)
+{
+    return 1;
+}
+
+stock Properties_OnPlayerPickUpPickup(playerid, pickupid)
+{
+    for(new i = 0; i < PropertyCount; i++)
+    {
+        if(PropertyData[i][prPickup] == pickupid)
+        {
+            PlayerPropertyTarget[playerid] = i;
+            Properties_ShowHint(playerid, i);
+            return 1;
+        }
+
+        if(PropertyData[i][prExitPickup] == pickupid && PlayerPropertyInside[playerid] == i)
+        {
+            Properties_Exit(playerid, i);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+stock Properties_ResetProperty(index)
+{
+    PropertyData[index][prSQLID] = 0;
+    PropertyData[index][prName][0] = '\0';
+    PropertyData[index][prPrice] = 0;
+    PropertyData[index][prOwnerID] = 0;
+    PropertyData[index][prOwnerName][0] = '\0';
+    PropertyData[index][prLocked] = 0;
+    PropertyData[index][prInterior] = 0;
+    PropertyData[index][prEnterX] = 0.0;
+    PropertyData[index][prEnterY] = 0.0;
+    PropertyData[index][prEnterZ] = 0.0;
+    PropertyData[index][prExitX] = 0.0;
+    PropertyData[index][prExitY] = 0.0;
+    PropertyData[index][prExitZ] = 0.0;
+    PropertyData[index][prPickup] = -1;
+    PropertyData[index][prExitPickup] = -1;
+    PropertyData[index][prLabel] = Text3D:INVALID_3DTEXT_ID;
+    PropertyData[index][prExitLabel] = Text3D:INVALID_3DTEXT_ID;
+    PropertyData[index][prVirtualWorld] = 0;
+}
+
+stock Properties_ResetPlayer(playerid)
+{
+    PlayerPropertyTarget[playerid] = -1;
+    PlayerPropertyInside[playerid] = -1;
+    PropertyDialogOptionCount[playerid] = 0;
+    PropertyDialogPendingAction[playerid] = PROPERTY_OPTION_NONE;
+    for(new i = 0; i < sizeof(PropertyDialogOptions[]); i++)
+    {
+        PropertyDialogOptions[playerid][i] = PROPERTY_OPTION_NONE;
+    }
+    return 1;
+}
+
+stock Properties_LoadAll()
+{
+    new query[256];
+    format(query, sizeof(query), "SELECT p.*, IFNULL(a.name, '') AS owner_name FROM properties p LEFT JOIN accounts a ON a.id = p.owner_id ORDER BY p.id ASC");
+
+    new DBResult:result = db_query(gDatabaseHandle, query);
+    if(!result)
+    {
+        return 0;
+    }
+
+    while(db_next_row(result))
+    {
+        if(PropertyCount >= MAX_PROPERTIES)
+        {
+            break;
+        }
+
+        new index = PropertyCount++;
+        PropertyData[index][prSQLID] = Database_FetchInt(result, "id");
+        Database_FetchString(result, "name", PropertyData[index][prName], sizeof(PropertyData[index][prName]));
+        Database_FetchString(result, "owner_name", PropertyData[index][prOwnerName], sizeof(PropertyData[index][prOwnerName]));
+        PropertyData[index][prPrice] = Database_FetchInt(result, "price");
+        PropertyData[index][prOwnerID] = Database_FetchInt(result, "owner_id");
+        PropertyData[index][prLocked] = Database_FetchInt(result, "locked");
+        PropertyData[index][prInterior] = Database_FetchInt(result, "interior");
+        PropertyData[index][prEnterX] = Database_FetchFloat(result, "enter_x");
+        PropertyData[index][prEnterY] = Database_FetchFloat(result, "enter_y");
+        PropertyData[index][prEnterZ] = Database_FetchFloat(result, "enter_z");
+        PropertyData[index][prExitX] = Database_FetchFloat(result, "exit_x");
+        PropertyData[index][prExitY] = Database_FetchFloat(result, "exit_y");
+        PropertyData[index][prExitZ] = Database_FetchFloat(result, "exit_z");
+
+        if(PropertyData[index][prOwnerID] == 0)
+        {
+            PropertyData[index][prLocked] = 0;
+            format(PropertyData[index][prOwnerName], sizeof(PropertyData[index][prOwnerName]), "Brak");
+        }
+
+        PropertyData[index][prVirtualWorld] = PROPERTY_VIRTUAL_BASE + PropertyData[index][prSQLID];
+        Properties_CreateVisual(index);
+        Properties_RefreshVisual(index);
+    }
+
+    db_free_result(result);
+    return 1;
+}
+
+stock Properties_CreateVisual(index)
+{
+    if(PropertyData[index][prPickup] != -1)
+    {
+        DestroyPickup(PropertyData[index][prPickup]);
+    }
+    if(PropertyData[index][prLabel] != Text3D:INVALID_3DTEXT_ID)
+    {
+        Delete3DTextLabel(PropertyData[index][prLabel]);
+    }
+    if(PropertyData[index][prExitPickup] != -1)
+    {
+        DestroyPickup(PropertyData[index][prExitPickup]);
+    }
+    if(PropertyData[index][prExitLabel] != Text3D:INVALID_3DTEXT_ID)
+    {
+        Delete3DTextLabel(PropertyData[index][prExitLabel]);
+    }
+
+    PropertyData[index][prPickup] = CreatePickup(1273, 23, Float:PropertyData[index][prEnterX], Float:PropertyData[index][prEnterY], Float:PropertyData[index][prEnterZ]);
+    PropertyData[index][prLabel] = Create3DTextLabel("", COLOR_WHITE, Float:PropertyData[index][prEnterX], Float:PropertyData[index][prEnterY], Float:PropertyData[index][prEnterZ] + 1.0, 30.0, 0, 0);
+
+    PropertyData[index][prExitPickup] = CreatePickup(19132, 1, Float:PropertyData[index][prExitX], Float:PropertyData[index][prExitY], Float:PropertyData[index][prExitZ], PropertyData[index][prVirtualWorld]);
+    PropertyData[index][prExitLabel] = Create3DTextLabel("Wyjscie\nUzyj /wyjdz", COLOR_WHITE, Float:PropertyData[index][prExitX], Float:PropertyData[index][prExitY], Float:PropertyData[index][prExitZ] + 0.8, 25.0, PropertyData[index][prVirtualWorld], 0);
+    return 1;
+}
+
+stock Properties_DestroyVisual(index)
+{
+    if(PropertyData[index][prPickup] != -1)
+    {
+        DestroyPickup(PropertyData[index][prPickup]);
+        PropertyData[index][prPickup] = -1;
+    }
+    if(PropertyData[index][prLabel] != Text3D:INVALID_3DTEXT_ID)
+    {
+        Delete3DTextLabel(PropertyData[index][prLabel]);
+        PropertyData[index][prLabel] = Text3D:INVALID_3DTEXT_ID;
+    }
+    if(PropertyData[index][prExitPickup] != -1)
+    {
+        DestroyPickup(PropertyData[index][prExitPickup]);
+        PropertyData[index][prExitPickup] = -1;
+    }
+    if(PropertyData[index][prExitLabel] != Text3D:INVALID_3DTEXT_ID)
+    {
+        Delete3DTextLabel(PropertyData[index][prExitLabel]);
+        PropertyData[index][prExitLabel] = Text3D:INVALID_3DTEXT_ID;
+    }
+    return 1;
+}
+
+stock Properties_RefreshVisual(index)
+{
+    if(index < 0 || index >= PropertyCount)
+    {
+        return 0;
+    }
+
+    new status[64];
+    if(PropertyData[index][prOwnerID] == 0)
+    {
+        format(status, sizeof(status), "Status: Na sprzedaz");
+    }
+    else
+    {
+        format(status, sizeof(status), "Wlasciciel: %s", PropertyData[index][prOwnerName]);
+    }
+
+    new lockStatus[64];
+    format(lockStatus, sizeof(lockStatus), "Drzwi: %s", PropertyData[index][prLocked] ? "Zamkniete" : "Otwarte");
+
+    new label[256];
+    format(label, sizeof(label), "%s\nCena: %d$\n%s\n%s\nKomenda: /dom", PropertyData[index][prName], PropertyData[index][prPrice], status, lockStatus);
+
+    Update3DTextLabelText(PropertyData[index][prLabel], COLOR_INFO, label);
+    return 1;
+}
+
+stock Properties_ShowMenu(playerid, propertyIndex)
+{
+    PropertyDialogOptionCount[playerid] = 0;
+    PlayerPropertyTarget[playerid] = propertyIndex;
+    for(new i = 0; i < sizeof(PropertyDialogOptions[]); i++)
+    {
+        PropertyDialogOptions[playerid][i] = PROPERTY_OPTION_NONE;
+    }
+
+    new info[256];
+    format(info, sizeof(info), "%s - cena %d$, drzwi %s", PropertyData[propertyIndex][prName], PropertyData[propertyIndex][prPrice], PropertyData[propertyIndex][prLocked] ? "zamkniete" : "otwarte");
+    SendClientMessage(playerid, COLOR_INFO, info);
+
+    new options[512];
+    options[0] = '\0';
+
+    if(PropertyData[propertyIndex][prOwnerID] == 0)
+    {
+        Properties_AddOption(playerid, PROPERTY_OPTION_PREVIEW, "Wejdz (podglad)", options, sizeof(options));
+        Properties_AddOption(playerid, PROPERTY_OPTION_BUY, "Kup dom", options, sizeof(options));
+    }
+    else if(PlayerData[playerid][pPropertyID] == PropertyData[propertyIndex][prSQLID])
+    {
+        Properties_AddOption(playerid, PROPERTY_OPTION_ENTER, "Wejdz do domu", options, sizeof(options));
+        Properties_AddOption(playerid, PROPERTY_OPTION_TOGGLE_LOCK, PropertyData[propertyIndex][prLocked] ? "Otworz drzwi" : "Zamknij drzwi", options, sizeof(options));
+        Properties_AddOption(playerid, PROPERTY_OPTION_SET_SPAWN, "Ustaw respawn w domu", options, sizeof(options));
+        Properties_AddOption(playerid, PROPERTY_OPTION_SELL, "Sprzedaj dom", options, sizeof(options));
+    }
+    else
+    {
+        if(!PropertyData[propertyIndex][prLocked])
+        {
+            Properties_AddOption(playerid, PROPERTY_OPTION_PREVIEW, "Wejdz (otwarte drzwi)", options, sizeof(options));
+        }
+    }
+
+    if(PropertyDialogOptionCount[playerid] == 0)
+    {
+        Properties_AddOption(playerid, PROPERTY_OPTION_NONE, "Brak dostepnych akcji", options, sizeof(options));
+    }
+
+    new title[64];
+    format(title, sizeof(title), "Nieruchomosc #%d", PropertyData[propertyIndex][prSQLID]);
+    ShowPlayerDialog(playerid, DIALOG_PROPERTY_MENU, DIALOG_STYLE_LIST, title, options, "Wybierz", "Zamknij");
+    return 1;
+}
+
+stock Properties_ShowConfirm(playerid, const message[])
+{
+    ShowPlayerDialog(playerid, DIALOG_PROPERTY_CONFIRM, DIALOG_STYLE_MSGBOX, "Potwierdzenie", message, "Tak", "Nie");
+    return 1;
+}
+
+stock Properties_AddOption(playerid, option, const label[], options[], size)
+{
+    new idx = PropertyDialogOptionCount[playerid];
+    if(idx >= sizeof(PropertyDialogOptions[]))
+    {
+        return 0;
+    }
+    PropertyDialogOptions[playerid][idx] = option;
+    PropertyDialogOptionCount[playerid]++;
+
+    if(idx == 0)
+    {
+        format(options, size, "%s", label);
+    }
+    else
+    {
+        strcat(options, "\n", size);
+        strcat(options, label, size);
+    }
+    return 1;
+}
+
+stock Properties_ExecuteAction(playerid, action)
+{
+    new index = PlayerPropertyTarget[playerid];
+    if(index == -1)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Brak wybranej nieruchomosci.");
+        return 1;
+    }
+
+    switch(action)
+    {
+        case PROPERTY_OPTION_ENTER:
+        {
+            Properties_Enter(playerid, index, false);
+            return 1;
+        }
+        case PROPERTY_OPTION_PREVIEW:
+        {
+            Properties_Enter(playerid, index, true);
+            return 1;
+        }
+        case PROPERTY_OPTION_BUY:
+        {
+            Properties_AttemptBuy(playerid, index);
+            break;
+        }
+        case PROPERTY_OPTION_SELL:
+        {
+            Properties_AttemptSell(playerid, index);
+            break;
+        }
+        case PROPERTY_OPTION_TOGGLE_LOCK:
+        {
+            Properties_ToggleLock(playerid, index);
+            break;
+        }
+        case PROPERTY_OPTION_SET_SPAWN:
+        {
+            Properties_SetSpawn(playerid, index);
+            break;
+        }
+        }
+
+    if(action == PROPERTY_OPTION_BUY || action == PROPERTY_OPTION_SELL || action == PROPERTY_OPTION_TOGGLE_LOCK || action == PROPERTY_OPTION_SET_SPAWN)
+    {
+        Properties_ShowMenu(playerid, index);
+    }
+    return 1;
+}
+
+stock Properties_Enter(playerid, index, bool:preview)
+{
+    if(index < 0 || index >= PropertyCount)
+    {
+        return 0;
+    }
+
+    if(PropertyData[index][prOwnerID] != 0 && PropertyData[index][prLocked] && PlayerData[playerid][pPropertyID] != PropertyData[index][prSQLID])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Drzwi sa zamkniete. Nie mozesz wejsc.");
+        return 1;
+    }
+
+    SetPlayerInterior(playerid, PropertyData[index][prInterior]);
+    SetPlayerVirtualWorld(playerid, PropertyData[index][prVirtualWorld]);
+    SetPlayerPos(playerid, Float:PropertyData[index][prExitX], Float:PropertyData[index][prExitY], Float:PropertyData[index][prExitZ]);
+    SetCameraBehindPlayer(playerid);
+    PlayerPropertyInside[playerid] = index;
+    PlayerPropertyTarget[playerid] = index;
+
+    if(preview && PropertyData[index][prOwnerID] == 0)
+    {
+        SendClientMessage(playerid, COLOR_INFO, "Ogladasz wnetrze nieruchomosci. Uzyj /wyjdz aby wrocic.");
+    }
+    else
+    {
+        SendClientMessage(playerid, COLOR_INFO, "Wszedles do nieruchomosci.");
+    }
+    return 1;
+}
+
+stock Properties_Exit(playerid, index)
+{
+    if(index < 0 || index >= PropertyCount)
+    {
+        return 0;
+    }
+
+    SetPlayerInterior(playerid, 0);
+    SetPlayerVirtualWorld(playerid, 0);
+    SetPlayerPos(playerid, Float:PropertyData[index][prEnterX], Float:PropertyData[index][prEnterY], Float:PropertyData[index][prEnterZ]);
+    SetCameraBehindPlayer(playerid);
+    PlayerPropertyInside[playerid] = -1;
+    PlayerPropertyTarget[playerid] = index;
+    SendClientMessage(playerid, COLOR_INFO, "Opusciles nieruchomosc.");
+    return 1;
+}
+
+stock Properties_AttemptBuy(playerid, index)
+{
+    if(index < 0 || index >= PropertyCount)
+    {
+        return 0;
+    }
+
+    if(PlayerData[playerid][pID] <= 0)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Twoje konto nie jest poprawnie zaladowane.");
+        return 1;
+    }
+
+    if(PropertyData[index][prOwnerID] != 0)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Ten dom ma juz wlasciciela.");
+        return 1;
+    }
+
+    if(PlayerData[playerid][pPropertyID] != 0)
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Posiadasz juz nieruchomosc. Sprzedaj ja najpierw.");
+        return 1;
+    }
+
+    if(GetPlayerMoney(playerid) < PropertyData[index][prPrice])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie masz wystarczajacej ilosci gotowki.");
+        return 1;
+    }
+
+    GivePlayerMoney(playerid, -PropertyData[index][prPrice]);
+    PlayerData[playerid][pMoney] = GetPlayerMoney(playerid);
+
+    PlayerData[playerid][pPropertyID] = PropertyData[index][prSQLID];
+    PlayerData[playerid][pPropertySpawn] = true;
+    PlayerData[playerid][pSpawnX] = PropertyData[index][prExitX];
+    PlayerData[playerid][pSpawnY] = PropertyData[index][prExitY];
+    PlayerData[playerid][pSpawnZ] = PropertyData[index][prExitZ];
+    PlayerData[playerid][pSpawnAngle] = 0.0;
+
+    PropertyData[index][prOwnerID] = PlayerData[playerid][pID];
+    GetPlayerName(playerid, PropertyData[index][prOwnerName], sizeof(PropertyData[index][prOwnerName]));
+    PropertyData[index][prLocked] = 1;
+    Properties_RefreshVisual(index);
+    PlayerPropertyTarget[playerid] = index;
+
+    new query[256];
+    format(query, sizeof(query), "UPDATE properties SET owner_id=%d, locked=1, updated_at=CURRENT_TIMESTAMP WHERE id=%d", PlayerData[playerid][pID], PropertyData[index][prSQLID]);
+    Database_Execute(query);
+
+    format(query, sizeof(query), "UPDATE accounts SET property_id=%d, property_spawn=1, spawn_x=%f, spawn_y=%f, spawn_z=%f, spawn_angle=%f WHERE id=%d",
+        PropertyData[index][prSQLID], Float:PropertyData[index][prExitX], Float:PropertyData[index][prExitY], Float:PropertyData[index][prExitZ], 0.0, PlayerData[playerid][pID]);
+    Database_Execute(query);
+
+    Properties_Log(PropertyData[index][prSQLID], PlayerData[playerid][pID], "BUY", "Zakup nieruchomosci");
+
+    SendClientMessage(playerid, COLOR_SUCCESS, "Zakupiles nieruchomosc. Ustawiono respawn w twoim domu.");
+    return 1;
+}
+
+stock Properties_AttemptSell(playerid, index)
+{
+    if(index < 0 || index >= PropertyCount)
+    {
+        return 0;
+    }
+
+    if(PlayerData[playerid][pPropertyID] != PropertyData[index][prSQLID])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie jestes wlascicielem tego domu.");
+        return 1;
+    }
+
+    if(PlayerPropertyInside[playerid] == index)
+    {
+        Properties_Exit(playerid, index);
+    }
+
+    new payout = floatround(PropertyData[index][prPrice] * 0.7, floatround_round);
+    GivePlayerMoney(playerid, payout);
+    PlayerData[playerid][pMoney] = GetPlayerMoney(playerid);
+
+    PlayerData[playerid][pPropertyID] = 0;
+    PlayerData[playerid][pPropertySpawn] = false;
+    PlayerData[playerid][pSpawnX] = 1958.3783;
+    PlayerData[playerid][pSpawnY] = 1343.1572;
+    PlayerData[playerid][pSpawnZ] = 15.3746;
+    PlayerData[playerid][pSpawnAngle] = 90.0;
+
+    PropertyData[index][prOwnerID] = 0;
+    format(PropertyData[index][prOwnerName], sizeof(PropertyData[index][prOwnerName]), "Brak");
+    PropertyData[index][prLocked] = 0;
+    Properties_RefreshVisual(index);
+    PlayerPropertyTarget[playerid] = index;
+
+    new query[256];
+    format(query, sizeof(query), "UPDATE properties SET owner_id=0, locked=0, updated_at=CURRENT_TIMESTAMP WHERE id=%d", PropertyData[index][prSQLID]);
+    Database_Execute(query);
+
+    format(query, sizeof(query), "UPDATE accounts SET property_id=0, property_spawn=0, spawn_x=%f, spawn_y=%f, spawn_z=%f, spawn_angle=%f WHERE id=%d",
+        1958.3783, 1343.1572, 15.3746, 90.0, PlayerData[playerid][pID]);
+    Database_Execute(query);
+
+    Properties_Log(PropertyData[index][prSQLID], PlayerData[playerid][pID], "SELL", "Sprzedaz nieruchomosci");
+
+    new message[144];
+    format(message, sizeof(message), "Sprzedales dom za %d$.", payout);
+    SendClientMessage(playerid, COLOR_SUCCESS, message);
+    return 1;
+}
+
+stock Properties_ToggleLock(playerid, index)
+{
+    if(index < 0 || index >= PropertyCount)
+    {
+        return 0;
+    }
+
+    if(PlayerData[playerid][pPropertyID] != PropertyData[index][prSQLID])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie jestes wlascicielem tego domu.");
+        return 1;
+    }
+
+    PropertyData[index][prLocked] = !PropertyData[index][prLocked];
+    Properties_RefreshVisual(index);
+    PlayerPropertyTarget[playerid] = index;
+
+    new query[256];
+    format(query, sizeof(query), "UPDATE properties SET locked=%d, updated_at=CURRENT_TIMESTAMP WHERE id=%d", PropertyData[index][prLocked], PropertyData[index][prSQLID]);
+    Database_Execute(query);
+
+    Properties_Log(PropertyData[index][prSQLID], PlayerData[playerid][pID], PropertyData[index][prLocked] ? "LOCK" : "UNLOCK", "Zmiana stanu drzwi");
+
+    SendClientMessage(playerid, COLOR_SUCCESS, PropertyData[index][prLocked] ? "Zamknales drzwi w swoim domu." : "Otworzyles drzwi w swoim domu.");
+    return 1;
+}
+
+stock Properties_SetSpawn(playerid, index)
+{
+    if(index < 0 || index >= PropertyCount)
+    {
+        return 0;
+    }
+
+    if(PlayerData[playerid][pPropertyID] != PropertyData[index][prSQLID])
+    {
+        SendClientMessage(playerid, COLOR_ERROR, "Nie jestes wlascicielem tego domu.");
+        return 1;
+    }
+
+    PlayerData[playerid][pSpawnX] = PropertyData[index][prExitX];
+    PlayerData[playerid][pSpawnY] = PropertyData[index][prExitY];
+    PlayerData[playerid][pSpawnZ] = PropertyData[index][prExitZ];
+    PlayerData[playerid][pSpawnAngle] = 0.0;
+    PlayerData[playerid][pPropertySpawn] = true;
+    PlayerPropertyTarget[playerid] = index;
+
+    if(PlayerData[playerid][pID] > 0)
+    {
+        new query[256];
+        format(query, sizeof(query), "UPDATE accounts SET spawn_x=%f, spawn_y=%f, spawn_z=%f, spawn_angle=%f, property_spawn=1 WHERE id=%d",
+            Float:PropertyData[index][prExitX], Float:PropertyData[index][prExitY], Float:PropertyData[index][prExitZ], 0.0, PlayerData[playerid][pID]);
+        Database_Execute(query);
+    }
+
+    SendClientMessage(playerid, COLOR_SUCCESS, "Ustawiles respawn wewnatrz domu.");
+    return 1;
+}
+
+stock Properties_ShowHint(playerid, index)
+{
+    new message[144];
+    if(PropertyData[index][prOwnerID] == 0)
+    {
+        format(message, sizeof(message), "Dom na sprzedaz: %s | Cena: %d$ | Uzyj /dom", PropertyData[index][prName], PropertyData[index][prPrice]);
+    }
+    else
+    {
+        format(message, sizeof(message), "Dom: %s | Wlasciciel: %s | Drzwi: %s | /dom", PropertyData[index][prName], PropertyData[index][prOwnerName], PropertyData[index][prLocked] ? "zamkniete" : "otwarte");
+    }
+    SendClientMessage(playerid, COLOR_INFO, message);
+    return 1;
+}
+
+stock Properties_FindByPickup(pickupid)
+{
+    for(new i = 0; i < PropertyCount; i++)
+    {
+        if(PropertyData[i][prPickup] == pickupid)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+stock Properties_FindBySQLID(sqlid)
+{
+    for(new i = 0; i < PropertyCount; i++)
+    {
+        if(PropertyData[i][prSQLID] == sqlid)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+stock Properties_FindNearest(playerid, Float:range)
+{
+    new nearest = -1;
+    new Float:bestDistance = range;
+
+    for(new i = 0; i < PropertyCount; i++)
+    {
+        new Float:distance = GetPlayerDistanceFromPoint(playerid, Float:PropertyData[i][prEnterX], Float:PropertyData[i][prEnterY], Float:PropertyData[i][prEnterZ]);
+        if(distance <= bestDistance)
+        {
+            bestDistance = distance;
+            nearest = i;
+        }
+    }
+    return nearest;
+}
+
+stock Properties_SeedDefaults()
+{
+    new query[128];
+    format(query, sizeof(query), "SELECT COUNT(*) AS count FROM properties");
+    new DBResult:result = db_query(gDatabaseHandle, query);
+
+    if(!result)
+    {
+        return 0;
+    }
+
+    db_next_row(result);
+    new count = Database_FetchInt(result, "count");
+    db_free_result(result);
+
+    if(count > 0)
+    {
+        return 1;
+    }
+
+    Properties_InsertSeed("Idlewood Apartament", 120000, 3, 2031.1562, -1119.0286, 26.3047, 235.5084, 1189.1699, 1080.3398);
+    Properties_InsertSeed("Willowfield Dom", 150000, 1, 2485.4966, -1692.2699, 14.7656, 223.1561, 1287.0870, 1082.1406);
+    Properties_InsertSeed("Marina Mieszkanie", 210000, 3, 812.8632, -1606.6682, 13.5469, 1527.2290, -11.5741, 1002.0971);
+    Properties_InsertSeed("Richman Rezydencja", 320000, 5, 1305.3121, -797.8125, 84.1406, 140.2670, 1366.2188, 1083.8633);
+    Properties_InsertSeed("Las Venturas Penthouse", 400000, 10, 2496.0273, 918.6331, 11.0156, 201.3653, 162.3589, 1003.0300);
+    return 1;
+}
+
+stock Properties_InsertSeed(const name[], price, interior, Float:enterX, Float:enterY, Float:enterZ, Float:exitX, Float:exitY, Float:exitZ)
+{
+    new escapedName[128];
+    Database_Escape(name, escapedName, sizeof(escapedName));
+
+    new query[512];
+    format(query, sizeof(query), "INSERT INTO properties (name, price, owner_id, locked, interior, enter_x, enter_y, enter_z, exit_x, exit_y, exit_z) VALUES ('%s', %d, 0, 0, %d, %f, %f, %f, %f, %f, %f)", escapedName, price, interior, enterX, enterY, enterZ, exitX, exitY, exitZ);
+    Database_Execute(query);
+    return 1;
+}
+
+stock Properties_Log(propertySQLID, accountID, const action[], const details[])
+{
+    new escapedDetails[256];
+    Database_Escape(details, escapedDetails, sizeof(escapedDetails));
+
+    new query[512];
+    format(query, sizeof(query), "INSERT INTO property_logs (property_id, account_id, action, details) VALUES (%d, %d, '%s', '%s')", propertySQLID, accountID, action, escapedDetails);
+    Database_Execute(query);
+    return 1;
+}
+
+stock Properties_GetPropertyName(sqlid, output[], size)
+{
+    for(new i = 0; i < PropertyCount; i++)
+    {
+        if(PropertyData[i][prSQLID] == sqlid)
+        {
+            format(output, size, "%s", PropertyData[i][prName]);
+            return 1;
+        }
+    }
+
+    format(output, size, "Brak");
+    return 0;
+}

--- a/inc/gamemode/vehicles.inc
+++ b/inc/gamemode/vehicles.inc
@@ -1,0 +1,373 @@
+#if defined _VEHICLES_MODULE_INCLUDED
+    #endinput
+#endif
+#define _VEHICLES_MODULE_INCLUDED
+
+#define VEHICLE_RESPAWN_CHECK_INTERVAL 60000
+
+forward Vehicles_Init();
+forward Vehicles_Shutdown();
+forward Vehicles_OnPlayerCommandText(playerid, cmdtext[]);
+forward Vehicles_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+forward Vehicles_OnVehicleSpawn(vehicleid);
+forward Vehicles_OnVehicleDeath(vehicleid, killerid);
+forward Vehicles_OnPlayerEnterVehicle(playerid, vehicleid, ispassenger);
+forward Vehicles_OnPlayerExitVehicle(playerid, vehicleid);
+forward Vehicles_LoadFromDatabase();
+forward Vehicles_Save(vehicleid);
+forward Vehicles_UpdateLastDriver(vehicleid, const name[]);
+forward Vehicles_Respawn(vehicleid);
+forward Vehicles_PerformRespawnCheck();
+forward Vehicles_StartRespawnTimer();
+
+enum E_VEHICLE_DATA
+{
+    bool:vExists,
+    vDBID,
+    vModel,
+    Float:vPosX,
+    Float:vPosY,
+    Float:vPosZ,
+    Float:vRot,
+    vColor1,
+    vColor2,
+    vRespawnDelay,
+    vOwner[32],
+    vLastDriver[MAX_PLAYER_NAME + 1],
+    vLastUsed
+};
+
+new VehicleData[MAX_VEHICLES][E_VEHICLE_DATA];
+new VehiclesRespawnTimer = -1;
+
+stock Vehicles_Init()
+{
+    for(new i = 0; i < MAX_VEHICLES; i++)
+    {
+        VehicleData[i][vExists] = false;
+        VehicleData[i][vDBID] = -1;
+        VehicleData[i][vModel] = 0;
+        VehicleData[i][vPosX] = 0.0;
+        VehicleData[i][vPosY] = 0.0;
+        VehicleData[i][vPosZ] = 0.0;
+        VehicleData[i][vRot] = 0.0;
+        VehicleData[i][vColor1] = 0;
+        VehicleData[i][vColor2] = 0;
+        VehicleData[i][vRespawnDelay] = 300;
+        VehicleData[i][vOwner][0] = '\0';
+        VehicleData[i][vLastDriver][0] = '\0';
+        VehicleData[i][vLastUsed] = 0;
+    }
+    Vehicles_LoadFromDatabase();
+    Vehicles_StartRespawnTimer();
+    Core_Log("[Vehicles] Zaladowano modul pojazdow.");
+    return 1;
+}
+
+stock Vehicles_Shutdown()
+{
+    if(VehiclesRespawnTimer != -1)
+    {
+        KillTimer(VehiclesRespawnTimer);
+        VehiclesRespawnTimer = -1;
+    }
+    for(new vehicleid = 0; vehicleid < MAX_VEHICLES; vehicleid++)
+    {
+        if(VehicleData[vehicleid][vExists])
+        {
+            Vehicles_Save(vehicleid);
+        }
+    }
+    Core_Log("[Vehicles] Zapisano dane pojazdow.");
+    return 1;
+}
+
+stock Vehicles_OnPlayerCommandText(playerid, cmdtext[])
+{
+    if(!PlayerData[playerid][pLogged])
+    {
+        return 0;
+    }
+
+    if(!strcmp(cmdtext, "/vinfo", true))
+    {
+        if(!IsPlayerInAnyVehicle(playerid))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Nie znajdujesz sie w zadnym pojezdzie.");
+            return 1;
+        }
+
+        new vehicleid = GetPlayerVehicleID(playerid);
+        if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Ten pojazd nie jest zarzadzany przez system.");
+            return 1;
+        }
+
+        new message[144];
+        format(message, sizeof(message), "ID DB: %d | Model: %d | Wlasciciel: %s", VehicleData[vehicleid][vDBID], VehicleData[vehicleid][vModel], VehicleData[vehicleid][vOwner]);
+        SendClientMessage(playerid, COLOR_INFO, message);
+
+        format(message, sizeof(message), "Ostatni kierowca: %s | Respawn: %d s", VehicleData[vehicleid][vLastDriver], VehicleData[vehicleid][vRespawnDelay]);
+        SendClientMessage(playerid, COLOR_INFO, message);
+        return 1;
+    }
+
+    if(!strcmp(cmdtext, "/vpark", true))
+    {
+        if(!IsPlayerInAnyVehicle(playerid))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Musisz znajdowac sie w pojezdzie jako kierowca.");
+            return 1;
+        }
+
+        new vehicleid = GetPlayerVehicleID(playerid);
+        if(GetPlayerState(playerid) != PLAYER_STATE_DRIVER)
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Nie jestes kierowca.");
+            return 1;
+        }
+
+        if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Ten pojazd nie jest zarzadzany przez system.");
+            return 1;
+        }
+
+        new Float:x, Float:y, Float:z, Float:angle;
+        GetVehiclePos(vehicleid, x, y, z);
+        GetVehicleZAngle(vehicleid, angle);
+
+        VehicleData[vehicleid][vPosX] = x;
+        VehicleData[vehicleid][vPosY] = y;
+        VehicleData[vehicleid][vPosZ] = z;
+        VehicleData[vehicleid][vRot] = angle;
+
+        Vehicles_Save(vehicleid);
+
+        SendClientMessage(playerid, COLOR_SUCCESS, "Zapisano nowa pozycje pojazdu.");
+        return 1;
+    }
+
+    if(!strcmp(cmdtext, "/vrespawn", true))
+    {
+        if(!Admin_IsPlayerAuthorized(playerid, 2))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Brak uprawnien do respawnowania pojazdow.");
+            return 1;
+        }
+
+        if(!IsPlayerInAnyVehicle(playerid))
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Wejdz do pojazdu aby go zrespawnowac.");
+            return 1;
+        }
+
+        new vehicleid = GetPlayerVehicleID(playerid);
+        if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+        {
+            SendClientMessage(playerid, COLOR_ERROR, "Ten pojazd nie jest zarzadzany przez system.");
+            return 1;
+        }
+
+        Vehicles_Respawn(vehicleid);
+        SendClientMessage(playerid, COLOR_SUCCESS, "Pojazd zostal zrespawnowany.");
+        return 1;
+    }
+
+    return 0;
+}
+
+stock Vehicles_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
+{
+    return 0;
+}
+
+stock Vehicles_OnVehicleSpawn(vehicleid)
+{
+    if(VehicleData[vehicleid][vExists])
+    {
+        SetVehiclePos(vehicleid, VehicleData[vehicleid][vPosX], VehicleData[vehicleid][vPosY], VehicleData[vehicleid][vPosZ]);
+        SetVehicleZAngle(vehicleid, VehicleData[vehicleid][vRot]);
+    }
+    return 1;
+}
+
+stock Vehicles_OnVehicleDeath(vehicleid, killerid)
+{
+    if(VehicleData[vehicleid][vExists])
+    {
+        SetTimerEx("Vehicles_Respawn", 5000, false, "d", vehicleid);
+    }
+    return 1;
+}
+
+stock Vehicles_OnPlayerEnterVehicle(playerid, vehicleid, ispassenger)
+{
+    if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+    {
+        return 0;
+    }
+
+    new name[MAX_PLAYER_NAME + 1];
+    GetPlayerName(playerid, name, sizeof(name));
+    Vehicles_UpdateLastDriver(vehicleid, name);
+
+    VehicleData[vehicleid][vLastUsed] = gettime();
+    return 1;
+}
+
+stock Vehicles_OnPlayerExitVehicle(playerid, vehicleid)
+{
+    if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+    {
+        return 0;
+    }
+    VehicleData[vehicleid][vLastUsed] = gettime();
+    return 1;
+}
+
+stock Vehicles_LoadFromDatabase()
+{
+    new DBResult:result = db_query(gDatabaseHandle, "SELECT * FROM vehicles");
+    if(!result)
+    {
+        Core_Log("[Vehicles] Brak danych pojazdow w bazie.");
+        return 0;
+    }
+
+    new rows = db_num_rows(result);
+    if(rows == 0)
+    {
+        Core_Log("[Vehicles] Baza pojazdow jest pusta.");
+        db_free_result(result);
+        return 1;
+    }
+
+    for(new i = 0; i < rows; i++)
+    {
+        if(i > 0) db_next_row(result);
+
+        new dbid = Database_FetchInt(result, "id");
+        new model = Database_FetchInt(result, "model");
+        new Float:x = Database_FetchFloat(result, "position_x");
+        new Float:y = Database_FetchFloat(result, "position_y");
+        new Float:z = Database_FetchFloat(result, "position_z");
+        new Float:rot = Database_FetchFloat(result, "rotation");
+        new color1 = Database_FetchInt(result, "color_1");
+        new color2 = Database_FetchInt(result, "color_2");
+        new respawnDelay = Database_FetchInt(result, "respawn_delay");
+
+        new vehicleid = CreateVehicle(model, x, y, z, rot, color1, color2, respawnDelay);
+        if(vehicleid == INVALID_VEHICLE_ID)
+        {
+            Core_Log("[Vehicles] Nie udalo sie utworzyc pojazdu z bazy.");
+            continue;
+        }
+
+        VehicleData[vehicleid][vExists] = true;
+        VehicleData[vehicleid][vDBID] = dbid;
+        VehicleData[vehicleid][vModel] = model;
+        VehicleData[vehicleid][vPosX] = x;
+        VehicleData[vehicleid][vPosY] = y;
+        VehicleData[vehicleid][vPosZ] = z;
+        VehicleData[vehicleid][vRot] = rot;
+        VehicleData[vehicleid][vColor1] = color1;
+        VehicleData[vehicleid][vColor2] = color2;
+        VehicleData[vehicleid][vRespawnDelay] = respawnDelay;
+        Database_FetchString(result, "owner", VehicleData[vehicleid][vOwner], sizeof(VehicleData[vehicleid][vOwner]));
+        Database_FetchString(result, "last_driver", VehicleData[vehicleid][vLastDriver], sizeof(VehicleData[vehicleid][vLastDriver]));
+        VehicleData[vehicleid][vLastUsed] = gettime();
+    }
+
+    db_free_result(result);
+    return 1;
+}
+
+stock Vehicles_Save(vehicleid)
+{
+    if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+    {
+        return 0;
+    }
+
+    new escapedDriver[2 * (MAX_PLAYER_NAME + 1)];
+    Database_Escape(VehicleData[vehicleid][vLastDriver], escapedDriver, sizeof(escapedDriver));
+
+    new query[256];
+    format(query, sizeof(query), "UPDATE vehicles SET position_x=%f, position_y=%f, position_z=%f, rotation=%f, last_driver='%s' WHERE id=%d",
+        VehicleData[vehicleid][vPosX], VehicleData[vehicleid][vPosY], VehicleData[vehicleid][vPosZ], VehicleData[vehicleid][vRot], escapedDriver, VehicleData[vehicleid][vDBID]);
+    Database_Execute(query);
+    return 1;
+}
+
+stock Vehicles_UpdateLastDriver(vehicleid, const name[])
+{
+    if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+    {
+        return 0;
+    }
+    format(VehicleData[vehicleid][vLastDriver], sizeof(VehicleData[vehicleid][vLastDriver]), "%s", name);
+    Vehicles_Save(vehicleid);
+    return 1;
+}
+
+public Vehicles_Respawn(vehicleid)
+{
+    if(vehicleid == INVALID_VEHICLE_ID || !VehicleData[vehicleid][vExists])
+    {
+        return 0;
+    }
+    SetVehicleToRespawn(vehicleid);
+    SetVehiclePos(vehicleid, VehicleData[vehicleid][vPosX], VehicleData[vehicleid][vPosY], VehicleData[vehicleid][vPosZ]);
+    SetVehicleZAngle(vehicleid, VehicleData[vehicleid][vRot]);
+    return 1;
+}
+
+public Vehicles_PerformRespawnCheck()
+{
+    new current = gettime();
+    for(new vehicleid = 0; vehicleid < MAX_VEHICLES; vehicleid++)
+    {
+        if(!VehicleData[vehicleid][vExists])
+        {
+            continue;
+        }
+
+        if(IsVehicleOccupied(vehicleid))
+        {
+            VehicleData[vehicleid][vLastUsed] = current;
+            continue;
+        }
+
+        if(current - VehicleData[vehicleid][vLastUsed] >= VehicleData[vehicleid][vRespawnDelay])
+        {
+            Vehicles_Respawn(vehicleid);
+            VehicleData[vehicleid][vLastUsed] = current;
+        }
+    }
+    return 1;
+}
+
+stock Vehicles_StartRespawnTimer()
+{
+    if(VehiclesRespawnTimer != -1)
+    {
+        KillTimer(VehiclesRespawnTimer);
+    }
+    VehiclesRespawnTimer = SetTimer("Vehicles_PerformRespawnCheck", VEHICLE_RESPAWN_CHECK_INTERVAL, true);
+    return 1;
+}
+
+stock bool:IsVehicleOccupied(vehicleid)
+{
+    for(new i = 0; i < MAX_PLAYERS; i++)
+    {
+        if(IsPlayerConnected(i) && GetPlayerVehicleID(i) == vehicleid)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated economy module that persists bank balances, paychecks, transactions, and payday rewards with SQLite-backed commands such as /saldo, /wplac, /wyplac, and /przelej
- introduce a modular job system with an in-world job center, selection dialogs, courier delivery gameplay, and mechanic service interactions that feed into player paychecks and logging
- integrate the new systems into the gamemode lifecycle, extend player/core data, and create supporting database tables for finances, jobs, and history logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e57ce40574833090e2aadbd785d052